### PR TITLE
[refactor] 공동 삭제 폼 추가

### DIFF
--- a/components/dialogs/category-forms/category-delete-form.tsx
+++ b/components/dialogs/category-forms/category-delete-form.tsx
@@ -1,9 +1,6 @@
 "use client";
-
-import { useState } from "react";
 import { toast } from "sonner";
-import { GlassButton } from "@ui/glass-button";
-import { Input } from "@ui/input";
+import DeleteForm from "@/components/form/delete-form";
 import { Category } from "@/types/post";
 import { softDeleteCategory } from "@/app/post/actions";
 import { useSidebarStore } from "@/providers/sidebar-store-provider";
@@ -19,8 +16,6 @@ export default function CategoryDeleteForm({
   category: Category;
   onClose: () => void;
 }) {
-  const [confirmText, setConfirmText] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
   const { setCategoriesPending } = useSidebarStore(
     useShallow((state) => ({
       setCategoriesPending: state.setCategoriesPending,
@@ -33,11 +28,10 @@ export default function CategoryDeleteForm({
   );
 
   const handleDelete = async () => {
-    setIsSaving(true);
     if (!isValid) {
       notSavedToast();
       onClose();
-      return setIsSaving(false);
+      return;
     }
     try {
       const { error } = await softDeleteCategory(category.id);
@@ -52,33 +46,13 @@ export default function CategoryDeleteForm({
       toast.error("삭제 중 오류가 발생했습니다.");
     } finally {
       onClose();
-      setIsSaving(false);
     }
   };
 
   return (
     <div className="flex flex-col gap-4 p-2">
       <DialogDescription>{category.name}</DialogDescription>
-      <div className="text-sm">
-        삭제하시려면 <strong>지금 삭제</strong> 라고 입력하세요.
-      </div>
-      <div className="grid grid-cols-5 gap-2">
-        <Input
-          className="col-span-4"
-          placeholder="지금 삭제"
-          value={confirmText}
-          onChange={(e) => setConfirmText(e.currentTarget.value)}
-        />
-        <GlassButton
-          className="col-span-1"
-          variant="danger"
-          disabled={confirmText !== "지금 삭제"}
-          loading={isSaving}
-          onClick={handleDelete}
-        >
-          삭제
-        </GlassButton>
-      </div>
+      <DeleteForm onConfirm={handleDelete} onClose={onClose} entityLabel={category.name} />
     </div>
   );
 }

--- a/components/dialogs/post-forms/post-delete-form.tsx
+++ b/components/dialogs/post-forms/post-delete-form.tsx
@@ -1,9 +1,6 @@
 "use client";
-
-import { useState } from "react";
 import { toast } from "sonner";
-import { GlassButton } from "@ui/glass-button";
-import { Input } from "@ui/input";
+import DeleteForm from "@/components/form/delete-form";
 import { Post } from "@/types/post";
 import { softDeletePost } from "@/app/post/actions";
 import { useSidebarStore } from "@/providers/sidebar-store-provider";
@@ -20,8 +17,6 @@ export default function PostDeleteForm({
   post: Post;
   onClose: () => void;
 }) {
-  const [confirmText, setConfirmText] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
   const { selectedPostId, posts } = useSidebarStore(
     useShallow((state) => ({
       posts: state.posts,
@@ -41,11 +36,10 @@ export default function PostDeleteForm({
   );
 
   const handleDelete = async () => {
-    setIsSaving(true);
     if (!isValid) {
       notSavedToast();
       onClose();
-      return setIsSaving(false);
+      return;
     }
     try {
       const { error } = await softDeletePost(post.id);
@@ -71,33 +65,13 @@ export default function PostDeleteForm({
       toast.error("삭제 중 오류가 발생했습니다.");
     } finally {
       onClose();
-      setIsSaving(false);
     }
   };
 
   return (
     <div className="flex flex-col gap-4 p-2">
       <div>{post.title}</div>
-      <div className="text-sm">
-        삭제하시려면 <strong>지금 삭제</strong> 라고 입력하세요.
-      </div>
-      <div className="grid grid-cols-5 gap-2">
-        <Input
-          className="col-span-4"
-          placeholder="지금 삭제"
-          value={confirmText}
-          onChange={(e) => setConfirmText(e.currentTarget.value)}
-        />
-        <GlassButton
-          className="col-span-1"
-          variant="danger"
-          disabled={confirmText !== "지금 삭제"}
-          loading={isSaving}
-          onClick={handleDelete}
-        >
-          삭제
-        </GlassButton>
-      </div>
+      <DeleteForm onConfirm={handleDelete} onClose={onClose} entityLabel={post.title} />
     </div>
   );
 }

--- a/components/dialogs/subcategory-forms/subcategory-delete-form.tsx
+++ b/components/dialogs/subcategory-forms/subcategory-delete-form.tsx
@@ -1,9 +1,6 @@
 "use client";
-
-import { useState } from "react";
 import { toast } from "sonner";
-import { GlassButton } from "@ui/glass-button";
-import { Input } from "@ui/input";
+import DeleteForm from "@/components/form/delete-form";
 import { Subcategory } from "@/types/post";
 import { softDeleteSubcategory } from "@/app/post/actions";
 import { useSidebarStore } from "@/providers/sidebar-store-provider";
@@ -19,8 +16,6 @@ export default function SubcategoryDeleteForm({
   subcategory: Subcategory;
   onClose: () => void;
 }) {
-  const [confirmText, setConfirmText] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
   const { setCategoriesPending } = useSidebarStore(
     useShallow((state) => ({
       setCategoriesPending: state.setCategoriesPending,
@@ -33,11 +28,10 @@ export default function SubcategoryDeleteForm({
   );
 
   const handleDelete = async () => {
-    setIsSaving(true);
     if (!isValid) {
       notSavedToast();
       onClose();
-      return setIsSaving(false);
+      return;
     }
     try {
       const { error } = await softDeleteSubcategory(subcategory.id);
@@ -52,33 +46,17 @@ export default function SubcategoryDeleteForm({
       toast.error("삭제 중 오류가 발생했습니다.");
     } finally {
       onClose();
-      setIsSaving(false);
     }
   };
 
   return (
     <div className="flex flex-col gap-4 p-2">
       <DialogDescription>{subcategory.name}</DialogDescription>
-      <div className="text-sm">
-        삭제하시려면 <strong>지금 삭제</strong> 라고 입력하세요.
-      </div>
-      <div className="grid grid-cols-5 gap-2">
-        <Input
-          className="col-span-4"
-          placeholder="지금 삭제"
-          value={confirmText}
-          onChange={(e) => setConfirmText(e.currentTarget.value)}
-        />
-        <GlassButton
-          className="col-span-1"
-          variant="danger"
-          disabled={confirmText !== "지금 삭제"}
-          loading={isSaving}
-          onClick={handleDelete}
-        >
-          삭제
-        </GlassButton>
-      </div>
+      <DeleteForm
+        onConfirm={handleDelete}
+        onClose={onClose}
+        entityLabel={subcategory.name}
+      />
     </div>
   );
 }

--- a/components/form/delete-form.tsx
+++ b/components/form/delete-form.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
+import { GlassButton } from "@/components/ui/glass-button";
+import { Input } from "@/components/ui/input";
+import {
+  type DeleteConfirmForm,
+  DeleteConfirmSchema,
+} from "@/types/form-schemas";
+
+type DeleteFormProps = {
+  onConfirm: () => Promise<void>;
+  onClose?: () => void;
+  entityLabel?: string;
+  buttonText?: string;
+};
+
+export default function DeleteForm({
+  onConfirm,
+  onClose,
+  entityLabel,
+  buttonText = "삭제",
+}: DeleteFormProps) {
+  const form = useForm<DeleteConfirmForm>({
+    resolver: zodResolver(DeleteConfirmSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
+    delayError: 500,
+    shouldFocusError: false,
+    defaultValues: {},
+  });
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      await onConfirm();
+      onClose?.();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [onConfirm, onClose]);
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex flex-col gap-4 p-2"
+        onSubmit={form.handleSubmit(handleSubmit)}
+      >
+        {entityLabel ? <div className="text-sm">{entityLabel}</div> : null}
+        <div className="text-sm">
+          삭제하시려면 <strong>지금 삭제</strong> 라고 입력해주세요.
+        </div>
+        <div className="grid grid-cols-5 gap-2">
+          <FormField
+            name="confirm"
+            render={({ field }) => (
+              <FormItem className="col-span-4">
+                <FormControl>
+                  <Input
+                    placeholder="지금 삭제"
+                    autoComplete="off"
+                    value={typeof field.value === "string" ? field.value : ""}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={field.ref}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <GlassButton
+            className="col-span-1"
+            variant="danger"
+            loading={isSaving}
+            disabled={isSaving || !form.formState.isValid}
+            type="submit"
+          >
+            {buttonText}
+          </GlassButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/types/form-schemas.ts
+++ b/types/form-schemas.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+const messages = {
+  slug: "영문 소문자, 숫자, 하이픈(-)만 사용하세요",
+  titleRequired: "제목을 입력해주세요",
+  nameRequired: "이름을 입력해주세요",
+  selectSeries: "시리즈를 선택해주세요",
+  selectCategory: "주제를 선택해주세요",
+  shortDescMax: "요약은 최대 500자까지 입력 가능합니다",
+  deleteConfirm: "지금 삭제",
+} as const;
+
+export const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SlugField = z.string().regex(slugRegex, messages.slug);
+const NonEmpty = (msg: string) => z.string().min(1, msg);
+
+const PostBaseFields = {
+  url_slug: SlugField,
+  subcategory_id: NonEmpty(messages.selectSeries),
+  is_private: z.boolean(),
+};
+
+export const PostCreateSchema = z.object({
+  title: NonEmpty(messages.titleRequired),
+  ...PostBaseFields,
+});
+
+export const PostUpdateSchema = z.object(PostBaseFields).extend({
+  short_description: z
+    .string()
+    .max(500, messages.shortDescMax)
+    .optional()
+    .or(z.literal("")),
+});
+
+export const CategorySchema = z.object({
+  name: NonEmpty(messages.nameRequired),
+});
+
+const SubcategoryBase = z.object({
+  name: NonEmpty(messages.nameRequired),
+  category_id: NonEmpty(messages.selectCategory),
+  url_slug: SlugField,
+});
+
+export const SubcategoryCreateSchema = SubcategoryBase;
+export const SubcategoryUpdateSchema = SubcategoryBase;
+
+export const DeleteConfirmSchema = z.object({
+  confirm: z.literal(messages.deleteConfirm),
+});
+
+export type PostCreateForm = z.infer<typeof PostCreateSchema>;
+export type PostUpdateForm = z.infer<typeof PostUpdateSchema>;
+export type CategoryForm = z.infer<typeof CategorySchema>;
+export type SubcategoryCreateForm = z.infer<typeof SubcategoryCreateSchema>;
+export type SubcategoryUpdateForm = z.infer<typeof SubcategoryUpdateSchema>;
+export type DeleteConfirmForm = z.infer<typeof DeleteConfirmSchema>;


### PR DESCRIPTION
### 주요 변경 내용 (Key Changes)
- **공통 삭제 폼 컴포넌트 추가**  
  - `components/form/delete-form.tsx` 파일 만들어 공통화
  - 이 폼은 `react-hook-form`과 `zod`를 사용하여 `"지금 삭제"`라는 문자열이 입력 되어야 검증 
  - 기본 검증은 300ms 디바운스  

- **기존 삭제 폼 리팩터링**  
  - `PostDeleteForm`, `CategoryDeleteForm`, `SubcategoryDeleteForm`에 공통 삭제폼 적용  

- **Zod 스키마 중앙 관리**  
  - `types/form-schemas.ts` 파일 생성하여 폼 검증에 필요한 zod 스키마 정의
