### PR TITLE
Feat/inline : 인라인 편집기능 추가 

### DIFF
--- a/app/api/chat/inline/route.ts
+++ b/app/api/chat/inline/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { llmModel } from "@/app/api/chat/_controllers/utils/model";
+
+// 간단한 체인: 사용자 프롬프트와 선택된 마크다운을 받아 개선된 마크다운을 반환
+// - 필요 시 System 프롬프트/가이드라인을 강화 가능
+const systemTemplate = `You are an assistant that edits markdown inline.
+Follow the user's instruction and return only the edited markdown without extra commentary.`;
+
+export async function POST(request: NextRequest) {
+  try {
+    const { prompt, selectionMarkdown } = await request.json();
+    if (typeof prompt !== "string" || typeof selectionMarkdown !== "string") {
+      return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    }
+
+    const promptTemplate = ChatPromptTemplate.fromMessages([
+      ["system", systemTemplate],
+      [
+        "user",
+        "Instruction: {prompt}\n\nSelected Markdown:\n{selectionMarkdown}\n\nReturn only the edited markdown.",
+      ],
+    ]);
+
+    const chain = promptTemplate.pipe(llmModel);
+    const result = await chain.invoke({ prompt, selectionMarkdown });
+    const content: unknown = result.content;
+
+    const toText = (c: unknown): string => {
+      if (typeof c === "string") return c;
+      if (Array.isArray(c)) {
+        return c
+          .map((p) => {
+            if (typeof p === "string") return p;
+            if (p && typeof p === "object" && "text" in p) {
+              const textVal = (p as Record<string, unknown>).text;
+              return typeof textVal === "string" ? textVal : "";
+            }
+            return "";
+          })
+          .join("");
+      }
+      return String(c ?? "");
+    };
+
+    const text = toText(content).trim();
+
+    return NextResponse.json({ text });
+  } catch (error) {
+    console.error("/api/chat/inline error", error);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/api/chat/inline/route.ts
+++ b/app/api/chat/inline/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { MessageContent } from "@langchain/core/messages";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { llmModel } from "@/app/api/chat/_controllers/utils/model";
 
@@ -24,23 +25,23 @@ export async function POST(request: NextRequest) {
 
     const chain = promptTemplate.pipe(llmModel);
     const result = await chain.invoke({ prompt, selectionMarkdown });
-    const content: unknown = result.content;
+    const content = result.content;
 
-    const toText = (c: unknown): string => {
-      if (typeof c === "string") return c;
-      if (Array.isArray(c)) {
-        return c
-          .map((p) => {
-            if (typeof p === "string") return p;
-            if (p && typeof p === "object" && "text" in p) {
-              const textVal = (p as Record<string, unknown>).text;
+    const toText = (content: MessageContent): string => {
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        return content
+          .map((complex) => {
+            if (typeof complex === "string") return complex;
+            if (complex && typeof complex === "object" && "text" in complex) {
+              const textVal = complex.text;
               return typeof textVal === "string" ? textVal : "";
             }
             return "";
           })
           .join("");
       }
-      return String(c ?? "");
+      return String(content ?? "");
     };
 
     const text = toText(content).trim();

--- a/app/api/chat/inline/route.ts
+++ b/app/api/chat/inline/route.ts
@@ -6,7 +6,7 @@ import { llmModel } from "@/app/api/chat/_controllers/utils/model";
 // 간단한 체인: 사용자 프롬프트와 선택된 마크다운을 받아 개선된 마크다운을 반환
 // - 필요 시 System 프롬프트/가이드라인을 강화 가능
 const systemTemplate = `You are an assistant that edits markdown inline.
-Follow the user's instruction and return only the edited markdown without extra commentary.`;
+Follow the user's instruction and return only the edited markdown without extra commentary. Use rich markdown syntax`;
 
 export async function POST(request: NextRequest) {
   try {

--- a/components/markdown/milkdown-app/ai-inline-dock.tsx
+++ b/components/markdown/milkdown-app/ai-inline-dock.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Loader2, Send } from "lucide-react";
-import { Ctx } from "@milkdown/kit/ctx";
+import { Loader2, Send, Wand2 } from "lucide-react";
 import { editorViewCtx } from "@milkdown/kit/core";
+import { Ctx } from "@milkdown/kit/ctx";
 import { cn } from "@/lib/utils";
 import { useAiInlineStore } from "@/providers/ai-inline-store-provider";
 import { clearHighlight } from "./highlight-plugin";
@@ -10,13 +10,10 @@ interface AiInlineDockProps {
   onSubmit: (prompt: string, ctx: Ctx) => void;
 }
 
-export default function AiInlineDock({
-  onSubmit,
-}: AiInlineDockProps) {
+export default function AiInlineDock({ onSubmit }: AiInlineDockProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const [prompt, setPrompt] = useState<string>("");
 
-  // 전역 상태 사용
   const isOpen = useAiInlineStore((state) => state.isOpen);
   const isLoading = useAiInlineStore((state) => state.isLoading);
   const position = useAiInlineStore((state) => state.position);
@@ -69,16 +66,17 @@ export default function AiInlineDock({
   return (
     <div
       ref={panelRef}
-      className="absolute z-50 w-[320px] max-w-[80vw]"
+      className="absolute z-50 w-[320px] max-w-[100vw]"
       style={{
         left: position.x,
         top: position.y,
-        transform: "translate(-50%, calc(-100% - 8px))", // 기준점 위쪽에 살짝 띄우기
+        transform: "translate(-50%, calc(-100% - 8px))",
       }}
       aria-label="AI 인라인 편집 독"
       role="dialog"
     >
       <div className="relative">
+        <Wand2 className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 opacity-50" />
         <input
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
@@ -92,7 +90,7 @@ export default function AiInlineDock({
             "w-full min-h-[42px] rounded-xl border border-neutral-400 bg-white shadow-sm",
             "dark:border-neutral-500 dark:bg-neutral-900",
             "placeholder:text-neutral-300 dark:placeholder:text-neutral-600 text-sm text-neutral-900 dark:text-neutral-100",
-            "py-3 px-4 pr-12 focus:outline-none",
+            "py-3 pl-8 pr-12 focus:outline-none",
           )}
           placeholder="AI에게 편집 요청하기..."
           autoFocus

--- a/components/markdown/milkdown-app/ai-inline-dock.tsx
+++ b/components/markdown/milkdown-app/ai-inline-dock.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Ctx } from "@milkdown/kit/ctx";
+import { Send } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface AiInlineDockProps {
@@ -58,10 +59,7 @@ export default function AiInlineDock({
   return (
     <div
       ref={panelRef}
-      className={cn(
-        "absolute z-50 w-[320px] max-w-[80vw] rounded-xl border border-neutral-200 bg-white p-3 shadow-xl",
-        "dark:border-neutral-800 dark:bg-neutral-900",
-      )}
+      className="absolute z-50 w-[320px] max-w-[80vw]"
       style={{
         left: x,
         top: y,
@@ -70,7 +68,7 @@ export default function AiInlineDock({
       aria-label="AI 인라인 편집 독"
       role="dialog"
     >
-      <div className="flex items-center gap-2">
+      <div className="relative">
         <input
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
@@ -81,23 +79,25 @@ export default function AiInlineDock({
             }
           }}
           className={cn(
-            "flex-1 rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm",
-            "placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-400",
-            "dark:border-neutral-700 dark:bg-neutral-900 dark:placeholder:text-neutral-500 dark:focus:ring-neutral-600",
+            "w-full min-h-[42px] rounded-xl border border-neutral-400 bg-white shadow-sm",
+            "dark:border-neutral-500 dark:bg-neutral-900",
+            "placeholder:text-neutral-300 dark:placeholder:text-neutral-600 text-sm text-neutral-900 dark:text-neutral-100",
+            "py-3 px-4 pr-12 focus:outline-none",
           )}
-          placeholder="프롬프트를 입력하세요..."
+          placeholder="AI에게 편집 요청하기..."
+          autoFocus
         />
         <button
           type="button"
           disabled={!ctx || !prompt.trim()}
           onClick={handleSubmit}
           className={cn(
-            "inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium",
-            "bg-black text-white hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50",
-            "dark:bg-white dark:text-black dark:hover:bg-neutral-200",
+            "absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 rounded-lg flex items-center justify-center",
+            "bg-neutral-700 hover:bg-neutral-800 disabled:bg-neutral-300 dark:disabled:bg-neutral-600",
+            "transition-colors disabled:cursor-not-allowed",
           )}
         >
-          전송
+          <Send className="w-3.5 h-3.5 text-white" />
         </button>
       </div>
     </div>

--- a/components/markdown/milkdown-app/ai-inline-dock.tsx
+++ b/components/markdown/milkdown-app/ai-inline-dock.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, Send } from "lucide-react";
 import { Ctx } from "@milkdown/kit/ctx";
-import { Send } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface AiInlineDockProps {
@@ -8,6 +8,7 @@ interface AiInlineDockProps {
   x: number;
   y: number;
   ctx: Ctx | null;
+  isLoading?: boolean;
   onClose: () => void;
   onSubmit: (prompt: string, ctx: Ctx) => void;
 }
@@ -17,6 +18,7 @@ export default function AiInlineDock({
   x,
   y,
   ctx,
+  isLoading = false,
   onClose,
   onSubmit,
 }: AiInlineDockProps) {
@@ -97,7 +99,11 @@ export default function AiInlineDock({
             "transition-colors disabled:cursor-not-allowed",
           )}
         >
-          <Send className="w-3.5 h-3.5 text-white" />
+          {isLoading ? (
+            <Loader2 className="w-3.5 h-3.5 text-white animate-spin" />
+          ) : (
+            <Send className="w-3.5 h-3.5 text-white" />
+          )}
         </button>
       </div>
     </div>

--- a/components/markdown/milkdown-app/ai-inline-dock.tsx
+++ b/components/markdown/milkdown-app/ai-inline-dock.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, Send, Wand2 } from "lucide-react";
 import { editorViewCtx } from "@milkdown/kit/core";
 import { Ctx } from "@milkdown/kit/ctx";
+import { clearHighlight } from "@/lib/milkdown/plugins/highlight-plugin";
 import { cn } from "@/lib/utils";
 import { useAiInlineStore } from "@/providers/ai-inline-store-provider";
-import { clearHighlight } from "./highlight-plugin";
 
 interface AiInlineDockProps {
   onSubmit: (prompt: string, ctx: Ctx) => void;
@@ -20,7 +20,6 @@ export default function AiInlineDock({ onSubmit }: AiInlineDockProps) {
   const ctx = useAiInlineStore((state) => state.ctx);
   const closeDock = useAiInlineStore((state) => state.closeDock);
 
-  // 독 닫기 핸들러
   const handleClose = useCallback(() => {
     // 하이라이트 제거
     if (ctx) {

--- a/components/markdown/milkdown-app/ai-inline-dock.tsx
+++ b/components/markdown/milkdown-app/ai-inline-dock.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Ctx } from "@milkdown/kit/ctx";
+import { cn } from "@/lib/utils";
+
+interface AiInlineDockProps {
+  open: boolean;
+  x: number;
+  y: number;
+  ctx: Ctx | null;
+  onClose: () => void;
+  onSubmit: (prompt: string, ctx: Ctx) => void;
+}
+
+export default function AiInlineDock({
+  open,
+  x,
+  y,
+  ctx,
+  onClose,
+  onSubmit,
+}: AiInlineDockProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [prompt, setPrompt] = useState<string>("");
+
+  // 바깥 클릭으로 닫기
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!panelRef.current) return;
+      if (!panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open, onClose]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const handleSubmit = useCallback(() => {
+    if (!ctx) return;
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed, ctx);
+    setPrompt("");
+  }, [ctx, onSubmit, prompt]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      className={cn(
+        "absolute z-50 w-[320px] max-w-[80vw] rounded-xl border border-neutral-200 bg-white p-3 shadow-xl",
+        "dark:border-neutral-800 dark:bg-neutral-900",
+      )}
+      style={{
+        left: x,
+        top: y,
+        transform: "translate(-50%, calc(-100% - 8px))", // 기준점 위쪽에 살짝 띄우기
+      }}
+      aria-label="AI 인라인 편집 독"
+      role="dialog"
+    >
+      <div className="flex items-center gap-2">
+        <input
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          className={cn(
+            "flex-1 rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm",
+            "placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-400",
+            "dark:border-neutral-700 dark:bg-neutral-900 dark:placeholder:text-neutral-500 dark:focus:ring-neutral-600",
+          )}
+          placeholder="프롬프트를 입력하세요..."
+        />
+        <button
+          type="button"
+          disabled={!ctx || !prompt.trim()}
+          onClick={handleSubmit}
+          className={cn(
+            "inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium",
+            "bg-black text-white hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50",
+            "dark:bg-white dark:text-black dark:hover:bg-neutral-200",
+          )}
+        >
+          전송
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/markdown/milkdown-app/highlight-plugin.ts
+++ b/components/markdown/milkdown-app/highlight-plugin.ts
@@ -1,0 +1,105 @@
+import { Plugin, PluginKey } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
+import { EditorView } from "@milkdown/kit/prose/view";
+import { EditorState } from "@milkdown/kit/prose/state";
+import { $prose } from "@milkdown/kit/utils";
+
+export interface HighlightState {
+  decorations: DecorationSet;
+  highlightRange: { from: number; to: number } | null;
+}
+
+export const highlightPluginKey = new PluginKey<HighlightState>("highlight");
+
+export interface HighlightPluginOptions {
+  className?: string;
+  enabled?: boolean;
+}
+
+// ProseMirror 플러그인 생성 함수
+function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) {
+  const { className = "milkdown-selection-highlight", enabled = false } = options;
+
+  return new Plugin<HighlightState>({
+    key: highlightPluginKey,
+    
+    state: {
+      init() {
+        return {
+          decorations: DecorationSet.empty,
+          highlightRange: null,
+        };
+      },
+      
+      apply(tr, oldState) {
+        let { decorations, highlightRange } = oldState;
+        
+        // 트랜잭션이 선택을 변경했거나 문서를 수정했다면 데코레이션을 업데이트
+        if (tr.docChanged || tr.selectionSet) {
+          decorations = decorations.map(tr.mapping, tr.doc);
+        }
+        
+        // 메타데이터를 통해 하이라이트 상태 업데이트
+        const meta = tr.getMeta(highlightPluginKey);
+        if (meta) {
+          if (meta.type === "setHighlight") {
+            highlightRange = meta.range;
+            if (highlightRange) {
+              const decoration = Decoration.inline(
+                highlightRange.from,
+                highlightRange.to,
+                { class: className }
+              );
+              decorations = DecorationSet.create(tr.doc, [decoration]);
+            } else {
+              decorations = DecorationSet.empty;
+            }
+          } else if (meta.type === "clearHighlight") {
+            highlightRange = null;
+            decorations = DecorationSet.empty;
+          }
+        }
+        
+        return { decorations, highlightRange };
+      },
+    },
+    
+    props: {
+      decorations(state) {
+        if (!enabled) return null;
+        return this.getState(state)?.decorations || DecorationSet.empty;
+      },
+    },
+  });
+}
+
+// Milkdown 플러그인으로 래핑
+export const highlightPlugin = $prose(() => 
+  createProseMirrorHighlightPlugin({ 
+    className: "milkdown-selection-highlight", 
+    enabled: true 
+  })
+);
+
+// 하이라이트 설정 헬퍼 함수
+export function setHighlight(view: EditorView, from: number, to: number) {
+  const tr = view.state.tr.setMeta(highlightPluginKey, {
+    type: "setHighlight",
+    range: { from, to },
+  });
+  view.dispatch(tr);
+}
+
+// 하이라이트 제거 헬퍼 함수
+export function clearHighlight(view: EditorView) {
+  const tr = view.state.tr.setMeta(highlightPluginKey, {
+    type: "clearHighlight",
+  });
+  view.dispatch(tr);
+}
+
+// 현재 하이라이트 범위 가져오기
+export function getHighlightRange(state: EditorState): { from: number; to: number } | null {
+  const pluginState = highlightPluginKey.getState(state);
+  return pluginState?.highlightRange || null;
+}

--- a/components/markdown/milkdown-app/milkdown-app.tsx
+++ b/components/markdown/milkdown-app/milkdown-app.tsx
@@ -41,6 +41,7 @@ const MilkdownEditor = ({
     y: 0,
   });
   const [aiCtx, setAiCtx] = useState<Ctx | null>(null);
+  const [isAiLoading, setIsAiLoading] = useState<boolean>(false);
   const [highlightEnabled, setHighlightEnabled] = useState<boolean>(false);
   const [selectedRange, setSelectedRange] = useState<{
     from: number;
@@ -51,6 +52,9 @@ const MilkdownEditor = ({
   const handleAiSubmit = useCallback((prompt: string, ctx: Ctx) => {
     const editor = crepeRef.current?.editor;
     if (!editor) return;
+
+    // 로딩 시작
+    setIsAiLoading(true);
 
     const view = ctx.get(editorViewCtx);
     const { from, to } = view.state.selection;
@@ -86,6 +90,8 @@ const MilkdownEditor = ({
         console.error("inline replace error", e);
       })
       .finally(() => {
+        // 로딩 종료
+        setIsAiLoading(false);
         setAiDockOpen(false);
         setHighlightEnabled(false);
         setSelectedRange(null);
@@ -261,6 +267,7 @@ const MilkdownEditor = ({
         x={aiDockPos.x}
         y={aiDockPos.y}
         ctx={aiCtx}
+        isLoading={isAiLoading}
         onClose={() => {
           setAiDockOpen(false);
           setHighlightEnabled(false);

--- a/components/markdown/milkdown-app/milkdown-app.tsx
+++ b/components/markdown/milkdown-app/milkdown-app.tsx
@@ -5,6 +5,7 @@ import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
 import { Ctx } from "@milkdown/kit/ctx";
 import { Slice } from "@milkdown/kit/prose/model";
 import { Selection } from "@milkdown/kit/prose/state";
+import { getMarkdown } from "@milkdown/kit/utils";
 import { Milkdown, useEditor } from "@milkdown/react";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import AiInlineDock from "./ai-inline-dock";
@@ -35,12 +36,18 @@ const MilkdownEditor = ({
   });
   const [aiCtx, setAiCtx] = useState<Ctx | null>(null);
 
-  // AI 제출 핸들러 (필요 시 서버 액션/호출 연결)
-  const handleAiSubmit = useCallback((prompt: string, _ctx: Ctx) => {
-    // TODO: 프롬프트로 변환/삽입 로직 연결
-    // 현재는 자리표시자. 필요 시 서버 액션 호출 후 결과를 에디터에 반영.
-    // 예시: console.log(prompt, ctx)
+  // AI 제출 핸들러: 선택 영역을 마크다운으로 추출해 로그 출력
+  const handleAiSubmit = useCallback((prompt: string, ctx: Ctx) => {
+    const editor = crepeRef.current?.editor;
+    if (!editor) return;
+
+    const view = ctx.get(editorViewCtx);
+    const { from, to } = view.state.selection;
+
+    const selectionMarkdown = editor.action(getMarkdown({ from, to }));
     console.log("AI Prompt:", prompt);
+    console.log("Selection Markdown:", selectionMarkdown);
+
     setAiDockOpen(false);
   }, []);
 

--- a/components/markdown/milkdown-app/milkdown-app.tsx
+++ b/components/markdown/milkdown-app/milkdown-app.tsx
@@ -1,21 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EditorView } from "@codemirror/view";
-import { Crepe } from "@milkdown/crepe";
-import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
-import { Ctx } from "@milkdown/kit/ctx";
-import { Slice } from "@milkdown/kit/prose/model";
-import { Selection } from "@milkdown/kit/prose/state";
-import { getMarkdown } from "@milkdown/kit/utils";
-import { Milkdown, useEditor } from "@milkdown/react";
-import { vscodeDark } from "@uiw/codemirror-theme-vscode";
+import React, { useEffect, useRef, useState } from "react";
+import { editorViewCtx } from "@milkdown/kit/core";
+import { Milkdown } from "@milkdown/react";
 import "@/components/markdown/styles/milkdown-ai-highliting.css";
+import { useCrepeEditor } from "@/hooks/milkdown/useCrepeEditor";
+import { useHighlightSync } from "@/hooks/milkdown/useHighlightSync";
+import { useInlineAi } from "@/hooks/milkdown/useInlineAi";
+import { useMilkdownSync } from "@/hooks/milkdown/useMilkdownSync";
+import { setHighlight as setHighlightPlugin } from "@/lib/milkdown/plugins/highlight-plugin";
 import { useAiInlineStore } from "@/providers/ai-inline-store-provider";
 import AiInlineDock from "./ai-inline-dock";
-import {
-  clearHighlight,
-  highlightPlugin,
-  setHighlight as setHighlightPlugin,
-} from "./highlight-plugin";
 
 const MilkdownEditor = ({
   markdown,
@@ -32,87 +25,53 @@ const MilkdownEditor = ({
     return "";
   };
 
-  const crepeRef = useRef<Crepe | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const [body, setBody] = useState<string>(markdown);
 
-  // 전역 상태 사용 - 액션들만 가져오기
   const openDock = useAiInlineStore((state) => state.openDock);
-  const closeDock = useAiInlineStore((state) => state.closeDock);
-  const setLoading = useAiInlineStore((state) => state.setLoading);
   const setHighlight = useAiInlineStore((state) => state.setHighlight);
-
-  // 상태값들
   const isOpen = useAiInlineStore((state) => state.isOpen);
   const highlightEnabled = useAiInlineStore((state) => state.highlightEnabled);
   const selectedRange = useAiInlineStore((state) => state.selectedRange);
 
-  // AI 제출 핸들러: 선택 영역을 마크다운으로 추출해 로그 출력
-  const handleAiSubmit = useCallback(
-    (prompt: string, ctx: Ctx) => {
-      const editor = crepeRef.current?.editor;
-      if (!editor) return;
-
-      // 로딩 시작
-      setLoading(true);
-
+  // Crepe 에디터 초기화 훅
+  const { crepeRef } = useCrepeEditor({
+    initialMarkdown: markdown,
+    onImageUpload: onImageUpload ?? uploadImageToServer,
+    containerRef,
+    onMarkdownUpdated: (updated) => setBody(updated),
+    onAiToolbarOpen: ({ ctx, x, y, from, to }) => {
       const view = ctx.get(editorViewCtx);
-      // 치환 전, 에디터에 포커스를 강제로 부여해 상위 동기화 방향을 고정
-      view.focus();
-      const { from, to } = view.state.selection;
-
-      const selectionMarkdown = editor.action(getMarkdown({ from, to }));
-
-      // API 호출하여 변환된 마크다운 수신
-      fetch("/api/chat/inline", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt, selectionMarkdown }),
-      })
-        .then(async (res) => {
-          if (!res.ok) throw new Error("Inline API failed");
-          const data: { text?: string } = await res.json();
-          const replaced = (data.text ?? "").trim();
-          if (!replaced) return;
-
-          // 응답으로 선택 영역을 마크다운으로 교체 (마크다운 -> 노드 파싱 후 치환)
-          editor.action((innerCtx) => {
-            const innerView = innerCtx.get(editorViewCtx);
-            const parser = innerCtx.get(parserCtx);
-            const doc = parser(replaced);
-            if (!doc) return;
-
-            const tr = innerView.state.tr.replaceSelection(
-              new Slice(doc.content, 0, 0),
-            );
-            innerView.dispatch(tr);
-            // 치환 후에도 포커스를 유지해 상향 동기화가 발생하도록 함
-            try {
-              innerView.focus();
-            } catch (_) {}
-          });
-
-          // 에디터 내용 변경 후 body 상태 즉시 업데이트
-          const newMarkdown = editor.action(getMarkdown());
-          setBody(newMarkdown);
-          // 포커스 여부와 무관하게 부모에도 즉시 반영해 복원 덮어쓰기를 방지
-          setMarkdown(newMarkdown);
-        })
-        .catch((e) => {
-          console.error("inline replace error", e);
-        })
-        .finally(() => {
-          // 하이라이트 제거
-          const view = ctx.get(editorViewCtx);
-          clearHighlight(view);
-
-          // 전역 상태로 독 닫기 (로딩도 함께 종료)
-          closeDock();
-        });
+      if (from !== to) setHighlightPlugin(view, from, to);
+      setHighlight(true, { from, to });
+      openDock(x, y, ctx);
     },
-    [setLoading, closeDock, setMarkdown],
-  );
+  });
+
+  // 인라인 AI 제출 훅
+  const { submit: handleAiSubmit } = useInlineAi({
+    getSelectionMarkdown: () =>
+      crepeRef.current?.editor?.action?.(
+        (ctx: import("@milkdown/kit/ctx").Ctx) => {
+          const view = ctx.get(editorViewCtx);
+          const { from, to } = view.state.selection;
+          return view.state.doc.textBetween(from, to, "\n");
+        },
+      ) ?? "",
+    getFullMarkdown: () =>
+      crepeRef.current?.editor?.action?.(
+        (ctx: import("@milkdown/kit/ctx").Ctx) => {
+          const view = ctx.get(editorViewCtx);
+          return view.state.doc.textBetween(
+            0,
+            view.state.doc.content.size,
+            "\n",
+          );
+        },
+      ) ?? body,
+    setMarkdown,
+  });
 
   useEffect(() => {
     if (isFocused) {
@@ -120,157 +79,19 @@ const MilkdownEditor = ({
     }
   }, [body, isFocused, setMarkdown]);
 
-  // 하이라이트 상태 관리
-  useEffect(() => {
-    if (!crepeRef.current || !highlightEnabled) return;
+  useMilkdownSync({
+    editorRef: crepeRef,
+    isFocused,
+    markdown,
+    onBodyChange: setMarkdown,
+  });
 
-    const editor = crepeRef.current.editor;
-    if (!editor) return;
-
-    // 선택 영역이 변경되었을 때 하이라이트 업데이트
-    if (selectedRange && isOpen) {
-      editor.action((ctx) => {
-        const view = ctx.get(editorViewCtx);
-        setHighlightPlugin(view, selectedRange.from, selectedRange.to);
-      });
-    }
-  }, [highlightEnabled, selectedRange, isOpen]);
-
-  useEditor((root) => {
-    const crepe = new Crepe({
-      root,
-      defaultValue: markdown,
-      featureConfigs: {
-        [Crepe.Feature.ImageBlock]: {
-          async blockOnUpload(file) {
-            if (!onImageUpload) {
-              const imageUrl = await uploadImageToServer(file);
-              return imageUrl;
-            }
-            const imageUrl = await onImageUpload(file);
-            return imageUrl;
-          },
-        },
-        [Crepe.Feature.CodeMirror]: {
-          extensions: [EditorView.lineWrapping],
-          theme: vscodeDark,
-        },
-        [Crepe.Feature.Toolbar]: {
-          buildToolbar: (builder) => {
-            // builder.clear(); // 툴바 버튼들 삭제
-            builder.addGroup("ai", "AI"); // AI 그룹 추가
-            const functionGroup = builder.getGroup("ai");
-            functionGroup.addItem("ai-improve", {
-              icon: `<svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  {" "}
-                  <rect
-                    width="24"
-                    height="24"
-                    rx="4"
-                    fill="currentColor"
-                    opacity="0.12"
-                  />{" "}
-                  <text
-                    x="12"
-                    y="16"
-                    text-anchor="middle"
-                    font-size="10"
-                    font-family="sans-serif"
-                  >
-                    AI
-                  </text>{" "}
-                </svg>`,
-              active: () => true, // 활성화 상태
-              onRun: (ctx: Ctx) => {
-                // 1) 현재 선택 위치(from)의 뷰포트 좌표를 얻습니다.
-                const view = ctx.get(editorViewCtx);
-                const { from, to } = view.state.selection;
-                const { left, bottom } = view.coordsAtPos(from);
-
-                // 2) 에디터 컨테이너 기준 좌표로 환산합니다.
-                const container = containerRef.current;
-                if (!container) return;
-                const rect = container.getBoundingClientRect();
-                const offsetY = -70;
-                const offsetX = 150;
-
-                const x = left - rect.left + offsetX; // 컨테이너 기준 X
-                const y = bottom - rect.top + offsetY; // 컨테이너 기준 Y
-
-                // 3) 선택 영역이 있다면 하이라이트 설정
-                if (from !== to) {
-                  setHighlightPlugin(view, from, to);
-                  setHighlight(true, { from, to });
-                }
-
-                // 4) 팝업 상태를 열고 좌표/CTX를 반영합니다.
-                openDock(x, y, ctx);
-              },
-            });
-          },
-        },
-      },
-    });
-
-    crepe.on((listener) => {
-      listener.markdownUpdated((_, updatedMarkdown, prevMarkdown) => {
-        if (updatedMarkdown !== prevMarkdown) {
-          const cleaned = updatedMarkdown.replace(/<br\s*\/?>/gi, "&nbsp;");
-          setBody(cleaned);
-        }
-      });
-    });
-
-    // 하이라이트 플러그인 추가 (항상 활성화)
-    crepe.editor.use(highlightPlugin);
-
-    crepeRef.current = crepe;
-    return crepe;
-  }, []);
-
-  useEffect(() => {
-    if (!isFocused && crepeRef.current) {
-      try {
-        // 현재 에디터 마크다운과 외부 마크다운이 동일하면 재동기화를 건너뜀
-        const currentMarkdown = crepeRef.current.editor.action(getMarkdown());
-        if (currentMarkdown === markdown) return;
-
-        crepeRef.current.editor.action((ctx) => {
-          const view = ctx.get(editorViewCtx);
-          const parser = ctx.get(parserCtx);
-          const doc = parser(markdown);
-          if (!doc) return;
-
-          const state = view.state;
-          const selection = state.selection;
-          const { from } = selection;
-
-          let tr = state.tr;
-          tr = tr.replace(
-            0,
-            state.doc.content.size,
-            new Slice(doc.content, 0, 0),
-          );
-
-          if (tr.doc.content.size === 0) {
-            tr = tr.setSelection(Selection.atStart(tr.doc));
-          } else {
-            const safePos = Math.min(from, tr.doc.content.size - 1);
-            tr = tr.setSelection(Selection.near(tr.doc.resolve(safePos)));
-          }
-
-          view.dispatch(tr);
-        });
-      } catch (e) {
-        console.error(e);
-      }
-    }
-  }, [isFocused, markdown]);
+  useHighlightSync({
+    editorRef: crepeRef,
+    enabled: highlightEnabled,
+    isDockOpen: isOpen,
+    range: selectedRange,
+  });
 
   return (
     <div ref={containerRef} className="relative">

--- a/components/markdown/milkdown-app/milkdown-app.tsx
+++ b/components/markdown/milkdown-app/milkdown-app.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { EditorView } from "@codemirror/view";
 import { Crepe } from "@milkdown/crepe";
 import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
+import { Ctx } from "@milkdown/kit/ctx";
 import { Slice } from "@milkdown/kit/prose/model";
 import { Selection } from "@milkdown/kit/prose/state";
 import { Milkdown, useEditor } from "@milkdown/react";
@@ -50,6 +51,41 @@ const MilkdownEditor = ({
         [Crepe.Feature.CodeMirror]: {
           extensions: [EditorView.lineWrapping],
           theme: vscodeDark,
+        },
+        [Crepe.Feature.Toolbar]: {
+          buildToolbar: (builder) => {
+            builder.clear(); // 툴바 버튼들 삭제
+            builder.addGroup("ai", "AI"); // AI 그룹 추가
+            const functionGroup = builder.getGroup("ai");
+            functionGroup.addItem("ai-improve", {
+              icon: `<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  {" "}
+                  <rect
+                    width="24"
+                    height="24"
+                    rx="4"
+                    fill="currentColor"
+                    opacity="0.12"
+                  />{" "}
+                  <text
+                    x="12"
+                    y="16"
+                    text-anchor="middle"
+                    font-size="10"
+                    font-family="sans-serif"
+                  >
+                    AI
+                  </text>{" "}
+                </svg>`,
+              active: () => true, // 활성화 상태
+              onRun: (ctx: Ctx) => {},
+            });
+          },
         },
       },
     });

--- a/components/markdown/milkdown-app/milkdown-app.tsx
+++ b/components/markdown/milkdown-app/milkdown-app.tsx
@@ -104,7 +104,7 @@ const MilkdownEditor = ({
         },
         [Crepe.Feature.Toolbar]: {
           buildToolbar: (builder) => {
-            builder.clear(); // 툴바 버튼들 삭제
+            // builder.clear(); // 툴바 버튼들 삭제
             builder.addGroup("ai", "AI"); // AI 그룹 추가
             const functionGroup = builder.getGroup("ai");
             functionGroup.addItem("ai-improve", {
@@ -143,9 +143,11 @@ const MilkdownEditor = ({
                 const container = containerRef.current;
                 if (!container) return;
                 const rect = container.getBoundingClientRect();
+                const offsetY = -70;
+                const offsetX = 150;
 
-                const x = left - rect.left; // 컨테이너 기준 X
-                const y = bottom - rect.top + 8; // 컨테이너 기준 Y (버튼 위쪽에 살짝 오프셋 적용됨; 독 컴포넌트에서 위로 띄움)
+                const x = left - rect.left + offsetX; // 컨테이너 기준 X
+                const y = bottom - rect.top + offsetY; // 컨테이너 기준 Y
 
                 // 3) 팝업 상태를 열고 좌표/CTX를 반영합니다.
                 setAiCtx(ctx);

--- a/components/markdown/milkdown-app/milkdown-wrapper.tsx
+++ b/components/markdown/milkdown-app/milkdown-wrapper.tsx
@@ -6,6 +6,7 @@ import { useShallow } from "zustand/react/shallow";
 import { MilkdownProvider } from "@milkdown/react";
 import { useDebounce } from "@/hooks/use-debounce";
 import { cn } from "@/lib/utils";
+import { AiInlineStoreProvider } from "@/providers/ai-inline-store-provider";
 import { useAuthStore } from "@/providers/auth-provider";
 import { useAutosave } from "@/providers/autosave-store-provider";
 import { useLayoutStore } from "@/providers/layout-store-provider";
@@ -132,55 +133,57 @@ export default function MilkdownWrapper({ markdown }: { markdown: string }) {
   );
 
   return (
-    <MilkdownProvider>
-      <div
-        className={cn(
-          isMilkdownOn && isRawOn && "w-full grid grid-cols-2  left-0",
-        )}
-      >
+    <AiInlineStoreProvider>
+      <MilkdownProvider>
         <div
           className={cn(
-            !isMilkdownOn &&
-              isRawOn &&
-              "h-0 w-0 opacity-0 overflow-hidden pointer-events-none",
+            isMilkdownOn && isRawOn && "w-full grid grid-cols-2  left-0",
           )}
-          aria-hidden={!isMilkdownOn && isRawOn}
-          onFocus={() => {
-            setFocused("milkdown");
-            setMilkdownLoaded(true);
-          }}
         >
-          {isMilkdownLoaded && (
-            <DynamicMilkdownEditor
-              setMarkdown={setBody}
-              markdown={body}
-              onImageUpload={imageUploadHandler}
-              isFocused={focused === "milkdown"}
-            />
-          )}
+          <div
+            className={cn(
+              !isMilkdownOn &&
+                isRawOn &&
+                "h-0 w-0 opacity-0 overflow-hidden pointer-events-none",
+            )}
+            aria-hidden={!isMilkdownOn && isRawOn}
+            onFocus={() => {
+              setFocused("milkdown");
+              setMilkdownLoaded(true);
+            }}
+          >
+            {isMilkdownLoaded && (
+              <DynamicMilkdownEditor
+                setMarkdown={setBody}
+                markdown={body}
+                onImageUpload={imageUploadHandler}
+                isFocused={focused === "milkdown"}
+              />
+            )}
+          </div>
+          <div
+            className={cn(
+              isMilkdownOn &&
+                !isRawOn &&
+                "h-0 w-0 opacity-0 overflow-hidden pointer-events-none",
+            )}
+            aria-hidden={isMilkdownOn && !isRawOn}
+            onFocus={() => {
+              setFocused("codemirror");
+              setRawEditorLoaded(true);
+            }}
+          >
+            {isRawEditorLoaded && (
+              <DynamicMarkdownRawEditor
+                value={body}
+                onChange={setBody}
+                isFocused={focused === "codemirror"}
+              />
+            )}
+          </div>
         </div>
-        <div
-          className={cn(
-            isMilkdownOn &&
-              !isRawOn &&
-              "h-0 w-0 opacity-0 overflow-hidden pointer-events-none",
-          )}
-          aria-hidden={isMilkdownOn && !isRawOn}
-          onFocus={() => {
-            setFocused("codemirror");
-            setRawEditorLoaded(true);
-          }}
-        >
-          {isRawEditorLoaded && (
-            <DynamicMarkdownRawEditor
-              value={body}
-              onChange={setBody}
-              isFocused={focused === "codemirror"}
-            />
-          )}
-        </div>
-      </div>
-    </MilkdownProvider>
+      </MilkdownProvider>
+    </AiInlineStoreProvider>
   );
 }
 

--- a/components/markdown/styles/milkdown-ai-highliting.css
+++ b/components/markdown/styles/milkdown-ai-highliting.css
@@ -1,0 +1,42 @@
+/* 하이라이트 스타일 - 라이트 모드: 연한 노란색 */
+.milkdown-selection-highlight {
+  background: #fef3c7; /* 연한 노란색 */
+  border-radius: 3px;
+  padding: 1px 2px;
+  animation: highlightFadeIn 0.2s ease-in-out;
+  transition: background 0.15s ease-in-out;
+}
+
+@keyframes highlightFadeIn {
+  from {
+    background: #fbbf24; /* 시작: 더 진한 노란색 */
+  }
+  to {
+    background: #fef3c7; /* 끝: 연한 노란색 */
+  }
+}
+
+/* 다크모드에서의 하이라이트 스타일 */
+@media (prefers-color-scheme: dark) {
+  .milkdown .milkdown-selection-highlight,
+  [data-theme="dark"] .milkdown .milkdown-selection-highlight {
+    background: color-mix(in srgb, var(--crepe-color-primary), transparent 75%);
+  }
+
+  @keyframes highlightFadeIn {
+    from {
+      background: color-mix(
+        in srgb,
+        var(--crepe-color-primary),
+        transparent 55%
+      );
+    }
+    to {
+      background: color-mix(
+        in srgb,
+        var(--crepe-color-primary),
+        transparent 75%
+      );
+    }
+  }
+}

--- a/components/markdown/styles/milkdown-crepe-theme.css
+++ b/components/markdown/styles/milkdown-crepe-theme.css
@@ -457,3 +457,7 @@
   scroll-margin: 0;
   margin: 0;
 }
+
+.milkdown .milkdown-toolbar {
+  translate: 25% 0;
+}

--- a/components/markdown/styles/milkdown-crepe-theme.css
+++ b/components/markdown/styles/milkdown-crepe-theme.css
@@ -396,7 +396,7 @@
   line-height: 1.5;
 }
 
-.milkdown milkdown-code-block {
+.milkdown .milkdown-code-block {
   --crepe-color-background: #1a1a1a;
   --crepe-color-on-background: #e6e6e6;
   --crepe-color-surface: #121212;
@@ -434,7 +434,7 @@
   }
 }
 
-.milkdown milkdown-slash-menu .menu-groups .menu-group li {
+.milkdown .milkdown-slash-menu .menu-groups .menu-group li {
   min-width: 0px;
 }
 

--- a/components/markdown/styles/milkdown-crepe-theme.css
+++ b/components/markdown/styles/milkdown-crepe-theme.css
@@ -421,16 +421,25 @@
 
   .tools {
     display: flex;
-    justify-content: start;
+    justify-content: space-between;
   }
 
   .tools .language-button {
-    opacity: 0.5;
+    opacity: 0.8;
     z-index: 10;
   }
 
   .tools .language-button:hover {
     opacity: 1;
+  }
+
+  .tools .copy-button {
+    opacity: 0.5 !important;
+    z-index: 10;
+  }
+
+  .tools .copy-button:hover {
+    opacity: 1 !important;
   }
 }
 

--- a/hooks/milkdown/useCrepeEditor.ts
+++ b/hooks/milkdown/useCrepeEditor.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRef } from "react";
+import { EditorView } from "@codemirror/view";
+import { Crepe } from "@milkdown/crepe";
+import { editorViewCtx } from "@milkdown/kit/core";
+import { Ctx } from "@milkdown/kit/ctx";
+import { useEditor } from "@milkdown/react";
+import { vscodeDark } from "@uiw/codemirror-theme-vscode";
+import { highlightPlugin } from "@/lib/milkdown/plugins/highlight-plugin";
+
+type DockOpenHandler = (params: {
+  ctx: Ctx;
+  x: number;
+  y: number;
+  from: number;
+  to: number;
+}) => void;
+
+interface UseCrepeEditorOptions {
+  initialMarkdown: string;
+  onImageUpload?: (file: File) => Promise<string>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onMarkdownUpdated: (markdown: string) => void;
+  onAiToolbarOpen: DockOpenHandler;
+  toolbarOffset?: { x?: number; y?: number };
+}
+
+export function useCrepeEditor(options: UseCrepeEditorOptions) {
+  const {
+    initialMarkdown,
+    onImageUpload,
+    containerRef,
+    onMarkdownUpdated,
+    onAiToolbarOpen,
+    toolbarOffset,
+  } = options;
+
+  const crepeRef = useRef<Crepe | null>(null);
+
+  useEditor((root) => {
+    const crepe = new Crepe({
+      root,
+      defaultValue: initialMarkdown,
+      featureConfigs: {
+        [Crepe.Feature.ImageBlock]: {
+          async blockOnUpload(file) {
+            if (!onImageUpload) return "";
+            const url = await onImageUpload(file);
+            return url;
+          },
+        },
+        [Crepe.Feature.CodeMirror]: {
+          extensions: [EditorView.lineWrapping],
+          theme: vscodeDark,
+        },
+        [Crepe.Feature.Toolbar]: {
+          buildToolbar: (builder) => {
+            builder.addGroup("ai", "AI");
+            const functionGroup = builder.getGroup("ai");
+            functionGroup.addItem("ai-improve", {
+              icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><rect width="24" height="24" rx="4" fill="currentColor" opacity="0.12" /><text x="12" y="16" text-anchor="middle" font-size="10" font-family="sans-serif">AI</text></svg>`,
+              active: () => true,
+              onRun: (ctx: Ctx) => {
+                const view = ctx.get(editorViewCtx);
+                const { from, to } = view.state.selection;
+                const { left, bottom } = view.coordsAtPos(from);
+
+                const container = containerRef.current;
+                if (!container) return;
+                const rect = container.getBoundingClientRect();
+                const offsetY = toolbarOffset?.y ?? -70;
+                const offsetX = toolbarOffset?.x ?? 150;
+
+                const x = left - rect.left + offsetX;
+                const y = bottom - rect.top + offsetY;
+
+                onAiToolbarOpen({ ctx, x, y, from, to });
+              },
+            });
+          },
+        },
+      },
+    });
+
+    // 하이라이트 플러그인 항상 추가
+    crepe.editor.use(highlightPlugin);
+
+    // 마크다운 업데이트 이벤트 전달
+    crepe.on((listener) => {
+      listener.markdownUpdated((_, updatedMarkdown, prevMarkdown) => {
+        if (updatedMarkdown !== prevMarkdown) {
+          const cleaned = updatedMarkdown.replace(
+            /<br\s*\/?>(?=\n|$)/gi,
+            "&nbsp;",
+          );
+          onMarkdownUpdated(cleaned);
+        }
+      });
+    });
+
+    crepeRef.current = crepe;
+    return crepe;
+  }, []);
+
+  return { crepeRef };
+}

--- a/hooks/milkdown/useHighlightSync.ts
+++ b/hooks/milkdown/useHighlightSync.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Crepe } from "@milkdown/crepe";
+import type { Ctx } from "@milkdown/ctx";
+import { editorViewCtx } from "@milkdown/kit/core";
+import { setHighlight } from "@/lib/milkdown/plugins/highlight-plugin";
+
+interface UseHighlightSyncOptions {
+  editorRef: React.RefObject<Crepe | null>;
+  enabled: boolean;
+  isDockOpen: boolean;
+  range: { from: number; to: number } | null;
+}
+
+export function useHighlightSync({
+  editorRef,
+  enabled,
+  isDockOpen,
+  range,
+}: UseHighlightSyncOptions) {
+  useEffect(() => {
+    if (!enabled || !isDockOpen || !range) return;
+    const editor = editorRef.current?.editor;
+    if (!editor) return;
+    try {
+      editor.action((ctx: Ctx) => {
+        const view = ctx.get(editorViewCtx);
+        setHighlight(view, range.from, range.to);
+      });
+    } catch (_) {}
+  }, [enabled, isDockOpen, range, editorRef]);
+}

--- a/hooks/milkdown/useHighlightSync.ts
+++ b/hooks/milkdown/useHighlightSync.ts
@@ -23,11 +23,9 @@ export function useHighlightSync({
     if (!enabled || !isDockOpen || !range) return;
     const editor = editorRef.current?.editor;
     if (!editor) return;
-    try {
-      editor.action((ctx: Ctx) => {
-        const view = ctx.get(editorViewCtx);
-        setHighlight(view, range.from, range.to);
-      });
-    } catch (_) {}
+    editor.action((ctx: Ctx) => {
+      const view = ctx.get(editorViewCtx);
+      setHighlight(view, range.from, range.to);
+    });
   }, [enabled, isDockOpen, range, editorRef]);
 }

--- a/hooks/milkdown/useInlineAi.ts
+++ b/hooks/milkdown/useInlineAi.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback } from "react";
+import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
+import { Ctx } from "@milkdown/kit/ctx";
+import { Slice } from "@milkdown/kit/prose/model";
+import { clearHighlight } from "@/lib/milkdown/plugins/highlight-plugin";
+import { useAiInlineStore } from "@/providers/ai-inline-store-provider";
+
+interface UseInlineAiOptions {
+  getSelectionMarkdown: () => string;
+  getFullMarkdown: () => string;
+  setMarkdown: (markdown: string) => void;
+}
+
+export function useInlineAi({
+  getSelectionMarkdown,
+  getFullMarkdown,
+  setMarkdown,
+}: UseInlineAiOptions) {
+  const setLoading = useAiInlineStore((s) => s.setLoading);
+  const closeDock = useAiInlineStore((s) => s.closeDock);
+
+  const submit = useCallback(
+    (prompt: string, ctx: Ctx) => {
+      const view = ctx.get(editorViewCtx);
+      view.focus();
+
+      const selectionMarkdown = getSelectionMarkdown();
+      setLoading(true);
+
+      fetch("/api/chat/inline", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt, selectionMarkdown }),
+      })
+        .then(async (res) => {
+          if (!res.ok) throw new Error("Inline API failed");
+          const data: { text?: string } = await res.json();
+          const replaced = (data.text ?? "").trim();
+          if (!replaced) return;
+
+          const parser = ctx.get(parserCtx);
+          const doc = parser(replaced);
+          if (!doc) return;
+
+          const tr = view.state.tr.replaceSelection(
+            new Slice(doc.content, 0, 0),
+          );
+          view.dispatch(tr);
+          try {
+            view.focus();
+          } catch (_) {}
+
+          // 즉시 부모 상태 업데이트 (포커스와 무관)
+          const full = getFullMarkdown();
+          setMarkdown(full);
+        })
+        .catch((e) => {
+          console.error("inline replace error", e);
+        })
+        .finally(() => {
+          clearHighlight(view);
+          closeDock();
+          setLoading(false);
+        });
+    },
+    [getSelectionMarkdown, getFullMarkdown, setMarkdown, setLoading, closeDock],
+  );
+
+  return { submit };
+}

--- a/hooks/milkdown/useMilkdownSync.ts
+++ b/hooks/milkdown/useMilkdownSync.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Crepe } from "@milkdown/crepe";
+import { editorViewCtx, parserCtx } from "@milkdown/kit/core";
+import { Slice } from "@milkdown/kit/prose/model";
+import { Selection } from "@milkdown/kit/prose/state";
+import { getMarkdown } from "@milkdown/kit/utils";
+
+interface UseMilkdownSyncOptions {
+  editorRef: React.RefObject<Crepe | null>;
+  isFocused: boolean;
+  markdown: string;
+  onBodyChange: (val: string) => void;
+}
+
+export function useMilkdownSync({
+  editorRef,
+  isFocused,
+  markdown,
+  onBodyChange,
+}: UseMilkdownSyncOptions) {
+  // 포커스 상태에서 상향 동기화 (에디터 -> 상위)
+  useEffect(() => {
+    if (!isFocused) return;
+    const editor = editorRef.current?.editor;
+    if (!editor) return;
+    try {
+      const current = editor.action(getMarkdown());
+      if (typeof current === "string") onBodyChange(current);
+    } catch (_) {}
+  }, [isFocused, editorRef, onBodyChange]);
+
+  // 외부 markdown 변경 시 하향 동기화 (상위 -> 에디터)
+  useEffect(() => {
+    if (isFocused) return;
+    const editor = editorRef.current?.editor;
+    if (!editor) return;
+    try {
+      editor.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        const parser = ctx.get(parserCtx);
+        const doc = parser(markdown);
+        if (!doc) return;
+        const state = view.state;
+        const { from } = state.selection;
+        let tr = state.tr.replace(
+          0,
+          state.doc.content.size,
+          new Slice(doc.content, 0, 0),
+        );
+        if (tr.doc.content.size === 0) {
+          tr = tr.setSelection(Selection.atStart(tr.doc));
+        } else {
+          const safePos = Math.min(from, tr.doc.content.size - 1);
+          tr = tr.setSelection(Selection.near(tr.doc.resolve(safePos)));
+        }
+        view.dispatch(tr);
+      });
+    } catch (_) {}
+  }, [markdown, isFocused, editorRef]);
+}

--- a/hooks/milkdown/useMilkdownSync.ts
+++ b/hooks/milkdown/useMilkdownSync.ts
@@ -25,10 +25,8 @@ export function useMilkdownSync({
     if (!isFocused) return;
     const editor = editorRef.current?.editor;
     if (!editor) return;
-    try {
-      const current = editor.action(getMarkdown());
-      if (typeof current === "string") onBodyChange(current);
-    } catch (_) {}
+    const current = editor.action(getMarkdown());
+    if (typeof current === "string") onBodyChange(current);
   }, [isFocused, editorRef, onBodyChange]);
 
   // 외부 markdown 변경 시 하향 동기화 (상위 -> 에디터)
@@ -36,27 +34,25 @@ export function useMilkdownSync({
     if (isFocused) return;
     const editor = editorRef.current?.editor;
     if (!editor) return;
-    try {
-      editor.action((ctx) => {
-        const view = ctx.get(editorViewCtx);
-        const parser = ctx.get(parserCtx);
-        const doc = parser(markdown);
-        if (!doc) return;
-        const state = view.state;
-        const { from } = state.selection;
-        let tr = state.tr.replace(
-          0,
-          state.doc.content.size,
-          new Slice(doc.content, 0, 0),
-        );
-        if (tr.doc.content.size === 0) {
-          tr = tr.setSelection(Selection.atStart(tr.doc));
-        } else {
-          const safePos = Math.min(from, tr.doc.content.size - 1);
-          tr = tr.setSelection(Selection.near(tr.doc.resolve(safePos)));
-        }
-        view.dispatch(tr);
-      });
-    } catch (_) {}
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      const parser = ctx.get(parserCtx);
+      const doc = parser(markdown);
+      if (!doc) return;
+      const state = view.state;
+      const { from } = state.selection;
+      let tr = state.tr.replace(
+        0,
+        state.doc.content.size,
+        new Slice(doc.content, 0, 0),
+      );
+      if (tr.doc.content.size === 0) {
+        tr = tr.setSelection(Selection.atStart(tr.doc));
+      } else {
+        const safePos = Math.min(from, tr.doc.content.size - 1);
+        tr = tr.setSelection(Selection.near(tr.doc.resolve(safePos)));
+      }
+      view.dispatch(tr);
+    });
   }, [markdown, isFocused, editorRef]);
 }

--- a/hooks/zustand/use-ai-inline-store.tsx
+++ b/hooks/zustand/use-ai-inline-store.tsx
@@ -1,0 +1,76 @@
+import { createStore } from "zustand";
+import { Ctx } from "@milkdown/kit/ctx";
+
+export interface AiInlineState {
+  // UI 상태
+  isOpen: boolean;
+  isLoading: boolean;
+  position: { x: number; y: number };
+  
+  // Milkdown 컨텍스트
+  ctx: Ctx | null;
+  
+  // 하이라이트 관련
+  highlightEnabled: boolean;
+  selectedRange: { from: number; to: number } | null;
+  
+  // 액션들
+  openDock: (x: number, y: number, ctx: Ctx) => void;
+  closeDock: () => void;
+  setLoading: (loading: boolean) => void;
+  setHighlight: (enabled: boolean, range?: { from: number; to: number }) => void;
+  resetState: () => void;
+}
+
+export const createAiInlineStore = (initialState?: Partial<AiInlineState>) =>
+  createStore<AiInlineState>((set) => ({
+    // 초기 상태
+    isOpen: false,
+    isLoading: false,
+    position: { x: 0, y: 0 },
+    ctx: null,
+    highlightEnabled: false,
+    selectedRange: null,
+    
+    // 독 열기
+    openDock: (x, y, ctx) =>
+      set({
+        isOpen: true,
+        position: { x, y },
+        ctx,
+        isLoading: false,
+      }),
+    
+    // 독 닫기
+    closeDock: () =>
+      set({
+        isOpen: false,
+        isLoading: false,
+        highlightEnabled: false,
+        selectedRange: null,
+      }),
+    
+    // 로딩 상태 설정
+    setLoading: (loading) =>
+      set({ isLoading: loading }),
+    
+    // 하이라이트 설정
+    setHighlight: (enabled, range) =>
+      set({
+        highlightEnabled: enabled,
+        selectedRange: enabled ? range || null : null,
+      }),
+    
+    // 전체 상태 리셋
+    resetState: () =>
+      set({
+        isOpen: false,
+        isLoading: false,
+        position: { x: 0, y: 0 },
+        ctx: null,
+        highlightEnabled: false,
+        selectedRange: null,
+      }),
+    
+    ...initialState,
+  }));

--- a/lib/milkdown/plugins/highlight-plugin.ts
+++ b/lib/milkdown/plugins/highlight-plugin.ts
@@ -1,7 +1,7 @@
 import { Plugin, PluginKey } from "@milkdown/kit/prose/state";
+import { EditorState } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
 import { EditorView } from "@milkdown/kit/prose/view";
-import { EditorState } from "@milkdown/kit/prose/state";
 import { $prose } from "@milkdown/kit/utils";
 
 export interface HighlightState {
@@ -16,13 +16,15 @@ export interface HighlightPluginOptions {
   enabled?: boolean;
 }
 
-// ProseMirror 플러그인 생성 함수
-function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) {
-  const { className = "milkdown-selection-highlight", enabled = false } = options;
+function createProseMirrorHighlightPlugin(
+  options: HighlightPluginOptions = {},
+) {
+  const { className = "milkdown-selection-highlight", enabled = true } =
+    options;
 
   return new Plugin<HighlightState>({
     key: highlightPluginKey,
-    
+
     state: {
       init() {
         return {
@@ -30,16 +32,14 @@ function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) 
           highlightRange: null,
         };
       },
-      
+
       apply(tr, oldState) {
         let { decorations, highlightRange } = oldState;
-        
-        // 트랜잭션이 선택을 변경했거나 문서를 수정했다면 데코레이션을 업데이트
+
         if (tr.docChanged || tr.selectionSet) {
           decorations = decorations.map(tr.mapping, tr.doc);
         }
-        
-        // 메타데이터를 통해 하이라이트 상태 업데이트
+
         const meta = tr.getMeta(highlightPluginKey);
         if (meta) {
           if (meta.type === "setHighlight") {
@@ -48,7 +48,7 @@ function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) 
               const decoration = Decoration.inline(
                 highlightRange.from,
                 highlightRange.to,
-                { class: className }
+                { class: className },
               );
               decorations = DecorationSet.create(tr.doc, [decoration]);
             } else {
@@ -59,11 +59,11 @@ function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) 
             decorations = DecorationSet.empty;
           }
         }
-        
+
         return { decorations, highlightRange };
       },
     },
-    
+
     props: {
       decorations(state) {
         if (!enabled) return null;
@@ -73,15 +73,13 @@ function createProseMirrorHighlightPlugin(options: HighlightPluginOptions = {}) 
   });
 }
 
-// Milkdown 플러그인으로 래핑
-export const highlightPlugin = $prose(() => 
-  createProseMirrorHighlightPlugin({ 
-    className: "milkdown-selection-highlight", 
-    enabled: true 
-  })
+export const highlightPlugin = $prose(() =>
+  createProseMirrorHighlightPlugin({
+    className: "milkdown-selection-highlight",
+    enabled: true,
+  }),
 );
 
-// 하이라이트 설정 헬퍼 함수
 export function setHighlight(view: EditorView, from: number, to: number) {
   const tr = view.state.tr.setMeta(highlightPluginKey, {
     type: "setHighlight",
@@ -90,7 +88,6 @@ export function setHighlight(view: EditorView, from: number, to: number) {
   view.dispatch(tr);
 }
 
-// 하이라이트 제거 헬퍼 함수
 export function clearHighlight(view: EditorView) {
   const tr = view.state.tr.setMeta(highlightPluginKey, {
     type: "clearHighlight",
@@ -98,8 +95,9 @@ export function clearHighlight(view: EditorView) {
   view.dispatch(tr);
 }
 
-// 현재 하이라이트 범위 가져오기
-export function getHighlightRange(state: EditorState): { from: number; to: number } | null {
+export function getHighlightRange(
+  state: EditorState,
+): { from: number; to: number } | null {
   const pluginState = highlightPluginKey.getState(state);
   return pluginState?.highlightRange || null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-js-blog",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "private": true,
   "browserslist": [
     "> 0.5%",

--- a/providers/ai-inline-store-provider.tsx
+++ b/providers/ai-inline-store-provider.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  createAiInlineStore,
+  AiInlineState,
+} from "@/hooks/zustand/use-ai-inline-store";
+import { createContext, useRef, useContext, ReactNode } from "react";
+import { useStore } from "zustand";
+
+export type AiInlineStoreApi = ReturnType<typeof createAiInlineStore>;
+
+const AiInlineStoreContext = createContext<AiInlineStoreApi | undefined>(undefined);
+
+interface AiInlineStoreProviderProps {
+  children: ReactNode;
+  initialState?: Partial<AiInlineState>;
+}
+
+export const AiInlineStoreProvider = ({
+  children,
+  initialState,
+}: AiInlineStoreProviderProps) => {
+  const storeRef = useRef<AiInlineStoreApi>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = createAiInlineStore(initialState);
+  }
+
+  return (
+    <AiInlineStoreContext.Provider value={storeRef.current}>
+      {children}
+    </AiInlineStoreContext.Provider>
+  );
+};
+
+export const useAiInlineStore = <T,>(
+  selector: (store: AiInlineState) => T
+): T => {
+  const aiInlineStoreContext = useContext(AiInlineStoreContext);
+
+  if (!aiInlineStoreContext) {
+    throw new Error("useAiInlineStore must be used within AiInlineStoreProvider");
+  }
+
+  return useStore(aiInlineStoreContext, selector);
+};


### PR DESCRIPTION
### API Layer

**`app/api/chat/inline/route.ts`**

- AI 모델(LangChain)을 활용한 마크다운 편집 엔드포인트
- 사용자 프롬프트와 선택된 마크다운을 받아 개선된 마크다운 반환

### Hooks Layer

**`hooks/milkdown/useInlineAi.ts`**

- AI 편집 요청 처리 로직
- 선택된 텍스트를 AI API로 전송하고 결과를 에디터에 적용
- ProseMirror의 `replaceSelection`을 활용한 실시간 텍스트 교체

**`hooks/milkdown/useHighlightSync.ts`**

- 편집 독이 열려있을 때 선택된 텍스트 하이라이트 동기화
- 에디터의 상태와 UI 상태를 연결하는 브리지 역할

### Plugin Layer

**`lib/milkdown/plugins/highlight-plugin.ts`**

- ProseMirror 플러그인 기반 텍스트 하이라이트 시스템
- `setHighlight`, `clearHighlight`, `getHighlightRange` 함수 제공
- Decoration을 활용한 시각적 하이라이트 구현

### UI Components

**`components/markdown/milkdown-app/ai-inline-dock.tsx`**

- 플로팅 AI 편집 인터페이스
- 사용자 입력, 로딩 상태, 키보드/마우스 이벤트 처리
- Wand2 아이콘과 Send 버튼으로 직관적인 UI 제공

**`components/markdown/milkdown-app/milkdown-app.tsx`**

- 메인 에디터 컴포넌트
- 모든 훅과 컴포넌트를 통합하여 인라인 편집 기능 구현
- `onAiToolbarOpen` 콜백으로 편집 독 활성화

## 🔄 워크플로우

1. **텍스트 선택**: 사용자가 마크다운 에디터에서 텍스스 선택
2. **편집 독 활성화**: AI 툴바 버튼 클릭으로 편집 독 표시
3. **하이라이트 적용**: 선택된 텍스트 영역을 시각적으로 강조
4. **프롬프트 입력**: 사용자가 편집 요청사항을 입력
5. **AI 처리**: 백엔드 API에서 LangChain 모델로 텍스트 편집
6. **결과 적용**: 편집된 마크다운으로 선택 영역 교체
7. **상태 정리**: 하이라이트 제거 및 편집 독 닫기