### PR TITLE
[feat] Supabase 셀프호스팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,15 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!infra/supabase/.env.example
+
+# supabase self-host runtime data and local migration artifacts
+infra/supabase/.env
+infra/supabase/dumps/
+infra/supabase/rclone.conf
+infra/supabase/volumes/db/data/
+infra/supabase/volumes/storage/
+infra/supabase/volumes/snippets/
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ URL : [blog.jongchoi.com](https://blog.jongchoi.com)\
 
 > 2025.09.15 - TFS에서 Semantic Search로 게시글 검색 방식 변경, RAG 구현(임베딩 : EmbeddingGemma:300m, 리랭킹 : Jina Reranker v2)
 
-> 2026.06.05 - 주요 언어 모델을 GPT-OSS 20B, GPT-OSS 120B 기반 Ollama 모델로 변경
+> 2026.06.05 - Supabase Cloud에서 self-hosted Supabase로 데이터베이스 및 Storage를 이전하고, 주요 언어 모델을 GPT-OSS 20B, GPT-OSS 120B 기반 Ollama 모델로 변경
 
 ## 프로젝트 목표
 
@@ -206,3 +206,8 @@ URL : [blog.jongchoi.com](https://blog.jongchoi.com)\
   1. Webhook이나 Jenkins를 사용하는 방식과 달리 별도의 서버가 필요하지 않습니다.
   2. GitHub 레포지토리 내에서 환경변수를 안전하게 관리할 수 있고, 나머지 작업은 VPS에서 집중 관리하여 유지보수 및 확장면에서 용이합니다.
   3. VPS의 성능에 따라 GitHub Actions의 Hosted-Runner보다 빠른 속도로 빌드를 진행할 수 있게 됩니다. (OCI의 A1 인스턴스 사용)
+
+### Supabase 셀프 호스팅
+
+- 기존 Supabase Cloud에서 사용하던 Postgres, RLS, DB 함수, Storage 데이터를 VPS에 구성한 self-hosted Supabase로 이전하였습니다.
+- 애플리케이션은 self-hosted Supabase의 API URL과 anon/service role key를 사용하도록 구성하였으며, 게시글 데이터와 이미지 파일을 동일한 VPS 인프라 안에서 관리합니다.

--- a/infra/supabase/.env.example
+++ b/infra/supabase/.env.example
@@ -1,0 +1,367 @@
+############
+# Docker compose override files to layer on top of docker-compose.yml.
+# Native docker compose COMPOSE_FILE: colon-separated list, base file first.
+# Manage with: ./run.sh config add|remove <name>
+#
+# Examples:
+#   COMPOSE_FILE=docker-compose.yml
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.pg17.yml
+#
+############
+COMPOSE_FILE=compose.yaml:compose.minio.yaml
+
+
+############
+# Secrets
+#
+# YOU MUST CHANGE ALL THE DEFAULT VALUES BELOW BEFORE STARTING
+# THE CONTAINERS FOR THE FIRST TIME!
+#
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/docker#configuring-and-securing-supabase
+#
+# To generate secrets and API keys:
+# 1. sh utils/generate-keys.sh
+# 2. sh utils/add-new-auth-keys.sh
+#
+############
+
+# Postgres
+POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
+
+# Legacy symmetric HS256 key
+JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
+# Legacy API keys (HS256-signed JWTs)
+ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
+
+# Asymmetric key pair (ES256) and opaque API keys
+#
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys
+#
+# To generate:
+# sh ./utils/add-new-auth-keys.sh
+#
+# Opaque API key for client-side use (anon role).
+SUPABASE_PUBLISHABLE_KEY=
+# Opaque API key for server-side use (service_role). Never expose in client code.
+SUPABASE_SECRET_KEY=
+# JSON array of signing JWKs (EC private + legacy symmetric).
+# Used by Auth.
+JWT_KEYS=
+# JWKS for token verification (EC public + legacy symmetric).
+# Used by PostgREST, Realtime, Storage to verify tokens.
+JWT_JWKS=
+
+# Access to Dashboard
+DASHBOARD_USERNAME=supabase
+DASHBOARD_PASSWORD=this_password_is_insecure_and_should_be_updated
+
+# Used by Realtime and Supavisor
+SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
+
+# Used by Supavisor
+VAULT_ENC_KEY=your-32-character-encryption-key
+
+# Used by Studio to access Postgres via postgres-meta
+PG_META_CRYPTO_KEY=your-encryption-key-32-chars-min
+
+# Analytics - API tokens for log ingestion/querying, and for management
+# If Logflare has to be externally exposed - configure securely!
+# Used in the docker-compose.logs.yml override.
+LOGFLARE_PUBLIC_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-public
+LOGFLARE_PRIVATE_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-private
+
+# Access to Storage via S3 protocol endpoint (see below)
+S3_PROTOCOL_ACCESS_KEY_ID=625729a08b95bf1b7ff351a663f3a23c
+S3_PROTOCOL_ACCESS_KEY_SECRET=850181e4652dd023b7a98c58ae0d2d34bd487ee0cc3254aed6eda37307425907
+
+
+############
+# URLs - Configure hostnames below to reflect your actual domain name
+############
+
+# Access to Dashboard and REST API
+SUPABASE_PUBLIC_URL=https://blog-supabase.jongchoi.com
+
+# Full external URL of the Auth service, used to construct OAuth callbacks,
+# SAML endpoints, and email links
+API_EXTERNAL_URL=https://blog-supabase.jongchoi.com
+
+# See also the Auth section below for Site URL and Redirect URLs configuration
+
+
+############
+# Database - Postgres configuration
+############
+
+# Using default user (postgres)
+POSTGRES_HOST=db
+POSTGRES_DB=postgres
+
+# Default configuration includes Supavisor exposing POSTGRES_PORT
+# Postgres uses POSTGRES_PORT inside the container
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres-through-supavisor
+POSTGRES_PORT=5432
+
+
+############
+# Supavisor - Database pooler
+############
+
+# Supavisor exposes POSTGRES_PORT and POOLER_PROXY_PORT_TRANSACTION,
+# POSTGRES_PORT is used for session mode pooling
+#
+# Port to use for transaction mode pooling connections
+POOLER_PROXY_PORT_TRANSACTION=6543
+
+# Maximum number of PostgreSQL connections Supavisor opens per pool
+POOLER_DEFAULT_POOL_SIZE=20
+
+# Maximum number of client connections Supavisor accepts per pool
+POOLER_MAX_CLIENT_CONN=100
+
+# Unique Supavisor tenant identifier
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres
+POOLER_TENANT_ID=your-tenant-id
+
+# Pool size for internal metadata storage used by Supavisor
+# This is separate from client connections and used only by Supavisor itself
+POOLER_DB_POOL_SIZE=5
+
+
+############
+# Studio - Configuration for the Dashboard
+############
+
+STUDIO_DEFAULT_ORGANIZATION=Blog
+STUDIO_DEFAULT_PROJECT=scribbly
+
+# Add your OpenAI API key to enable AI Assistant
+OPENAI_API_KEY=sk-proj-xxxxxxxx
+
+
+############
+# Auth - Configuration for the authentication server
+############
+
+## General settings
+
+# Equivalent to "Site URL" and "Redirect URLs" platform configuration options
+# Documentation: https://supabase.com/docs/guides/auth/redirect-urls
+SITE_URL=https://blog.jongchoi.com
+ADDITIONAL_REDIRECT_URLS=https://blog.jongchoi.com/callback,http://localhost:3000/callback
+
+JWT_EXPIRY=3600
+DISABLE_SIGNUP=false
+
+## Mailer Config
+MAILER_URLPATHS_CONFIRMATION="/auth/v1/verify"
+MAILER_URLPATHS_INVITE="/auth/v1/verify"
+MAILER_URLPATHS_RECOVERY="/auth/v1/verify"
+MAILER_URLPATHS_EMAIL_CHANGE="/auth/v1/verify"
+
+## Email auth
+ENABLE_EMAIL_SIGNUP=true
+ENABLE_EMAIL_AUTOCONFIRM=false
+SMTP_ADMIN_EMAIL=admin@example.com
+SMTP_HOST=supabase-mail
+SMTP_PORT=2500
+SMTP_USER=fake_mail_user
+SMTP_PASS=fake_mail_password
+SMTP_SENDER_NAME=fake_sender
+ENABLE_ANONYMOUS_USERS=false
+
+## Phone auth
+ENABLE_PHONE_SIGNUP=true
+ENABLE_PHONE_AUTOCONFIRM=true
+
+## OAuth / Social login providers
+
+# Uncomment and fill in the providers you want to enable.
+# You must ALSO uncomment the matching GOTRUE_EXTERNAL_* lines in docker-compose.yml
+# Documentation: https://supabase.com/docs/guides/self-hosting/self-hosted-oauth
+GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
+GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=change-me-google-client-id
+GOTRUE_EXTERNAL_GOOGLE_SECRET=change-me-google-secret
+GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=https://blog-supabase.jongchoi.com/auth/v1/callback
+
+# GITHUB_ENABLED=false
+# GITHUB_CLIENT_ID=
+# GITHUB_SECRET=
+
+# AZURE_ENABLED=false
+# AZURE_CLIENT_ID=
+# AZURE_SECRET=
+
+# Phone / SMS provider configuration
+# Uncomment to configure SMS delivery for phone auth and phone MFA.
+# You must ALSO uncomment the matching GOTRUE_SMS_* lines in docker-compose.yml
+# Documentation: https://supabase.com/docs/guides/self-hosting/self-hosted-phone-mfa
+# SMS_PROVIDER=twilio
+# SMS_OTP_EXP=60
+# SMS_OTP_LENGTH=6
+# SMS_MAX_FREQUENCY=60s
+# SMS_TEMPLATE=Your code is {{ .Code }}
+
+# SMS_TWILIO_ACCOUNT_SID=
+# SMS_TWILIO_AUTH_TOKEN=
+# SMS_TWILIO_MESSAGE_SERVICE_SID=
+
+# Test OTP: map phone numbers to fixed OTP codes for development
+# Format: phone1:code1,phone2:code2
+# SMS_TEST_OTP=
+
+# Multi-factor authentication (MFA)
+# Uncomment to change MFA defaults.
+# You must ALSO uncomment the matching GOTRUE_MFA_* lines in docker-compose.yml
+
+# App Authenticator (TOTP) - enabled by default
+# MFA_TOTP_ENROLL_ENABLED=true
+# MFA_TOTP_VERIFY_ENABLED=true
+
+# Phone MFA - disabled by default (opt-in)
+# MFA_PHONE_ENROLL_ENABLED=false
+# MFA_PHONE_VERIFY_ENABLED=false
+
+# Maximum MFA factors a user can enroll
+# MFA_MAX_ENROLLED_FACTORS=10
+
+## SAML SSO
+
+# You must ALSO uncomment the matching GOTRUE_* lines in docker-compose.yml
+# Documentation: https://supabase.com/docs/guides/self-hosting/self-hosted-saml-sso
+
+# SAML_ENABLED=true
+# SAML_PRIVATE_KEY=<your-base64-encoded-private-key>
+
+# Optional: accept encrypted SAML assertions from IdPs (default: false)
+# SAML_ALLOW_ENCRYPTED_ASSERTIONS=false
+
+# Optional: how long relay state tokens remain valid (default: 2m0s)
+# SAML_RELAY_STATE_VALIDITY_PERIOD=2m0s
+
+# Optional: override the SAML entity ID / ACS base URL
+# Defaults to API_EXTERNAL_URL if not set
+# SAML_EXTERNAL_URL=https://supabase.example.com:8000
+
+# Optional: rate limit on the ACS endpoint (requests per second, default: 15)
+# SAML_RATE_LIMIT_ASSERTION=15
+
+
+############
+# Storage - Configuration for Storage
+############
+
+# Check the S3_PROTOCOL_ACCESS_KEY_ID/SECRET above, and
+# refer to the documentation at:
+# https://supabase.com/docs/guides/self-hosting/self-hosted-s3
+# to learn how to configure the S3 protocol endpoint
+
+# S3 bucket when using S3 backend, directory name when using 'file'
+GLOBAL_S3_BUCKET=image
+
+# Used for S3 protocol endpoint configuration
+REGION=ap-northeast-2
+
+# Used by MinIO when added via:
+# docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d
+MINIO_ROOT_USER=change-me-minio-root-user
+MINIO_ROOT_PASSWORD=change-me-minio-root-password
+
+# Equivalent to project_ref as described here:
+# https://supabase.com/docs/guides/storage/s3/authentication#session-token
+STORAGE_TENANT_ID=blog
+
+
+############
+# Functions - Configuration for Edge functions
+############
+
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/self-hosted-functions
+
+# NOTE: VERIFY_JWT applies to all functions
+FUNCTIONS_VERIFY_JWT=false
+
+
+############
+# API - Configuration for PostgREST
+############
+
+# Postgres schemas exposed via the REST API
+PGRST_DB_SCHEMAS=public,storage,graphql_public
+
+# Max number of rows returned by a request
+PGRST_DB_MAX_ROWS=1000
+
+# Extra schemas added to the search_path of every request
+PGRST_DB_EXTRA_SEARCH_PATH=public
+
+
+############
+# Logs and Analytics
+############
+
+## Vector log collection and routing
+
+# Docker socket location - required for proper Vector operation
+DOCKER_SOCKET_LOCATION=/var/run/docker.sock
+# For Podman use the following:
+# DOCKER_SOCKET_LOCATION=/run/podman/podman.sock
+
+## Analytics (Logflare)
+
+# Check the LOGFLARE_* access token configuration _above_.
+# If Logflare has to be externally exposed - configure securely!
+
+# Google Cloud Project details
+# Documentation:
+# https://supabase.com/docs/reference/self-hosting-analytics/introduction
+GOOGLE_PROJECT_ID=GOOGLE_PROJECT_ID
+GOOGLE_PROJECT_NUMBER=GOOGLE_PROJECT_NUMBER
+
+
+############
+# API gateway
+############
+
+# Kong configuration variables
+KONG_HTTP_PORT=8000
+KONG_HTTPS_PORT=8443
+
+# Used internally by the API gateway - DO NOT use in any client or server code.
+# Pre-signed ES256 JWT "API key" for anon role.
+ANON_KEY_ASYMMETRIC=
+# Pre-signed ES256 JWT "API key" for service_role.
+SERVICE_ROLE_KEY_ASYMMETRIC=
+
+
+############
+# imgproxy
+############
+
+# Enable webp support
+IMGPROXY_AUTO_WEBP=true
+
+
+############
+# TLS Proxy - Optional Caddy or Nginx reverse proxy with Let's Encrypt
+############
+
+# Documentation:
+# https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https
+
+# Usage:
+# docker compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
+# docker compose -f docker-compose.yml -f docker-compose.nginx.yml up -d
+
+# Domain name for the proxy (must point to your server)
+PROXY_DOMAIN=your-domain.example.com
+
+# Email for Let's Encrypt certificate notifications (nginx only, Caddy uses PROXY_DOMAIN).
+# This should be a valid email, not a placehoder (otherwise Certbot may fail to start).
+CERTBOT_EMAIL=admin@example.com

--- a/infra/supabase/README.md
+++ b/infra/supabase/README.md
@@ -1,0 +1,149 @@
+# Supabase self-host 운영 묶음
+
+`blog-supabase.jongchoi.com`에서 self-host Supabase를 띄우기 위한 Docker Compose 구성입니다. 기본 구성은 Supabase 공식 Docker compose를 기준으로 하며, 이 프로젝트에 맞춰 Google OAuth, Nginx Proxy Manager 네트워크, MinIO S3 backend를 연결합니다.
+
+## 1. 환경변수 준비
+
+```bash
+cp infra/supabase/.env.example infra/supabase/.env
+```
+
+`infra/supabase/.env`에서 아래 값은 반드시 실제 값으로 교체합니다.
+
+- `POSTGRES_PASSWORD`
+- `JWT_SECRET`
+- `ANON_KEY`
+- `SERVICE_ROLE_KEY`
+- `DASHBOARD_USERNAME`
+- `DASHBOARD_PASSWORD`
+- `SECRET_KEY_BASE`
+- `VAULT_ENC_KEY`
+- `PG_META_CRYPTO_KEY`
+- `S3_PROTOCOL_ACCESS_KEY_ID`
+- `S3_PROTOCOL_ACCESS_KEY_SECRET`
+- `MINIO_ROOT_USER`
+- `MINIO_ROOT_PASSWORD`
+- `GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID`
+- `GOTRUE_EXTERNAL_GOOGLE_SECRET`
+
+도메인 관련 값은 아래 기준으로 고정합니다.
+
+```env
+SITE_URL=https://blog.jongchoi.com
+API_EXTERNAL_URL=https://blog-supabase.jongchoi.com
+SUPABASE_PUBLIC_URL=https://blog-supabase.jongchoi.com
+ADDITIONAL_REDIRECT_URLS=https://blog.jongchoi.com/callback,http://localhost:3000/callback
+GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=https://blog-supabase.jongchoi.com/auth/v1/callback
+```
+
+## 2. Compose 확인과 실행
+
+Nginx Proxy Manager가 붙을 Docker network가 없다면 먼저 만듭니다.
+
+```bash
+docker network create npm-network
+```
+
+Compose 설정을 확인합니다.
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  config
+```
+
+Supabase와 MinIO를 실행합니다.
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  up -d
+```
+
+## 3. Nginx Proxy Manager 연결
+
+NPM에서 Proxy Host를 추가합니다.
+
+- Domain: `blog-supabase.jongchoi.com`
+- Forward Hostname / IP: `supabase-kong`
+- Forward Port: `8000`
+- SSL: Let's Encrypt 발급
+- Websockets Support: enabled
+
+연결 후 아래 엔드포인트가 응답하는지 확인합니다.
+
+```bash
+curl https://blog-supabase.jongchoi.com/auth/v1/health
+```
+
+## 4. Google OAuth
+
+Google Cloud Console의 OAuth Client에 아래 Authorized redirect URI를 등록합니다.
+
+```text
+https://blog-supabase.jongchoi.com/auth/v1/callback
+```
+
+앱의 로그인 코드는 `redirectTo: ${window.location.origin}/callback`을 사용하므로 변경하지 않습니다. self-host 이전 후 기존 Supabase Cloud 세션은 새 JWT와 맞지 않아서 다시 로그인해야 합니다.
+
+## 5. DB dump / restore
+
+Cloud Supabase에서 dump를 생성합니다.
+
+```bash
+CLOUD_DB_URL="postgres://..." scripts/supabase/dump.sh
+```
+
+생성되는 dump의 역할은 아래와 같습니다.
+
+- `roles.sql`: custom role과 권한
+- `schema.sql`: table, view, function, trigger, index, RLS policy 등 DB 구조
+- `data.sql`: table row, `auth.users`, Storage bucket metadata 등 데이터
+
+DB dump에는 Storage 실제 파일, OAuth provider env, JWT/API key, SMTP, Edge Functions, DNS 설정은 포함되지 않습니다.
+
+self-host DB로 복원합니다.
+
+```bash
+scripts/supabase/restore.sh
+```
+
+기본 복원 URL은 `infra/supabase/.env`의 `POSTGRES_PASSWORD`, `POOLER_TENANT_ID`와 `blog-supabase.jongchoi.com:5432`로 만들어집니다. 다른 DB 주소를 쓰려면 `SELF_HOSTED_DB_URL`을 직접 넘깁니다.
+
+복원 후에는 source/self-hosted 인벤토리를 비교합니다.
+
+```bash
+scripts/supabase/verify-db.sh
+```
+
+이 스크립트는 extension, public table/view/function/trigger, RLS policy, `auth.users` 수, Storage bucket metadata를 확인합니다.
+
+## 6. Storage 이전
+
+Supabase Cloud Dashboard의 Storage S3 Configuration에서 access key를 발급한 뒤 실행합니다.
+
+```bash
+PLATFORM_S3_ENDPOINT="https://<project-ref>.supabase.co/storage/v1/s3" \
+PLATFORM_S3_REGION="<cloud-region>" \
+PLATFORM_S3_ACCESS_KEY_ID="<cloud-access-key>" \
+PLATFORM_S3_SECRET_ACCESS_KEY="<cloud-secret-key>" \
+scripts/supabase/sync-storage.sh
+```
+
+기본 bucket은 `image`입니다. 전체 bucket을 복사하려면 `BUCKET=all`을 추가합니다.
+
+## 7. 앱 전환 체크
+
+앱 배포 환경변수를 self-host 값으로 바꿉니다.
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://blog-supabase.jongchoi.com
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<self-host anon key>
+SUPABASE_SERVICE_ROLE_KEY=<self-host service role key>
+```
+
+전환 후 확인할 항목은 Google OAuth 로그인, 이미지 업로드, 게시글 이미지 렌더링, semantic search RPC, admin 조회입니다.

--- a/infra/supabase/compose.minio.yaml
+++ b/infra/supabase/compose.minio.yaml
@@ -1,0 +1,46 @@
+services:
+
+  minio:
+    image: cgr.dev/chainguard/minio
+    #ports:
+    #  - '9000:9000'
+    #  - '9001:9001'
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    command: server --console-address ":9001" /data
+    healthcheck:
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 2s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - minio-data:/data
+
+  minio-createbucket:
+    image: cgr.dev/chainguard/minio-client:latest-dev
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -ec "
+      mc alias set supa-minio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD} &&
+      mc mb --ignore-existing supa-minio/${GLOBAL_S3_BUCKET}
+      "
+
+  storage:
+    depends_on:
+      minio-createbucket:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+    environment:
+      STORAGE_BACKEND: s3
+      GLOBAL_S3_ENDPOINT: http://minio:9000
+      GLOBAL_S3_PROTOCOL: http
+      GLOBAL_S3_FORCE_PATH_STYLE: true
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+
+volumes:
+  minio-data:

--- a/infra/supabase/compose.yaml
+++ b/infra/supabase/compose.yaml
@@ -1,0 +1,577 @@
+# Usage
+#   Start:              docker compose up -d
+#   Stop:               docker compose down
+#   Dev mode:           docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up -d
+#   Reset everything:   sh reset.sh
+#
+# TODO:
+#   - Podman does not support nested variable interpolation (${A:-${B}})
+#
+
+name: supabase
+
+services:
+
+  studio:
+    container_name: supabase-studio
+    image: supabase/studio:2026.06.03-sha-0bca601
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://localhost:3000/api/platform/profile').then((r) => {if (r.status !== 200) throw new Error(r.status)})\""
+        ]
+      timeout: 10s
+      interval: 5s
+      retries: 3
+      start_period: 20s
+    environment:
+      # Listen on all IPv4 interfaces
+      HOSTNAME: "0.0.0.0"
+
+      STUDIO_PG_META_URL: http://meta:8080
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+      # See: https://supabase.com/docs/guides/self-hosting/remove-superuser-access
+      #POSTGRES_USER_READ_WRITE: postgres
+
+      PG_META_CRYPTO_KEY: ${PG_META_CRYPTO_KEY}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+
+      DEFAULT_ORGANIZATION_NAME: ${STUDIO_DEFAULT_ORGANIZATION}
+      DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      AUTH_JWT_SECRET: ${JWT_SECRET}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY}
+
+      # See: docker-compose.logs.yml
+      ENABLED_FEATURES_LOGS_ALL: "false"
+
+      SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
+      EDGE_FUNCTIONS_MANAGEMENT_FOLDER: /app/edge-functions
+    volumes:
+      - ./volumes/snippets:/app/snippets:z
+      - ./volumes/functions:/app/edge-functions:ro,z
+
+  kong:
+    container_name: supabase-kong
+    image: kong/kong:3.9.1
+    restart: unless-stopped
+    networks:
+      default:
+        aliases:
+          - api-gw
+      npm-network:
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      studio:
+        condition: service_healthy
+    ports:
+      - ${KONG_HTTP_PORT}:8000/tcp
+      - ${KONG_HTTPS_PORT}:8443/tcp
+    volumes:
+      - ./volumes/api/kong.yml:/home/kong/temp.yml:ro,z
+      - ./volumes/api/kong-entrypoint.sh:/home/kong/kong-entrypoint.sh:ro,z
+      #- ./volumes/api/server.crt:/home/kong/server.crt:ro
+      #- ./volumes/api/server.key:/home/kong/server.key:ro
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
+      # https://github.com/supabase/cli/issues/14
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_NOT_FOUND_TTL: 1
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth,request-termination,ip-restriction,post-function
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      KONG_PROXY_ACCESS_LOG: /dev/stdout combined
+      #KONG_SSL_CERT: /home/kong/server.crt
+      #KONG_SSL_CERT_KEY: /home/kong/server.key
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY:-}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
+      ANON_KEY_ASYMMETRIC: ${ANON_KEY_ASYMMETRIC:-}
+      SERVICE_ROLE_KEY_ASYMMETRIC: ${SERVICE_ROLE_KEY_ASYMMETRIC:-}
+      DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
+      DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
+    entrypoint: /home/kong/kong-entrypoint.sh
+
+  auth:
+    container_name: supabase-auth
+    image: supabase/gotrue:v2.189.0
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:9999/health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL}
+
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+
+      GOTRUE_SITE_URL: ${SITE_URL}
+      GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
+      GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP}
+
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_EXP: ${JWT_EXPIRY}
+
+      # Legacy symmetric HS256 key
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
+
+      # JSON array of signing JWKs (EC private + legacy symmetric)
+      # For Podman, use: GOTRUE_JWT_KEYS: ${JWT_KEYS}
+      #GOTRUE_JWT_KEYS: ${JWT_KEYS:-[]}
+
+      GOTRUE_JWT_ISSUER: ${API_EXTERNAL_URL}/auth/v1
+
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: ${ENABLE_EMAIL_SIGNUP}
+      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: ${ENABLE_ANONYMOUS_USERS}
+      GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM}
+
+      # Uncomment to bypass nonce check in ID Token flow. Commonly set to true when using Google Sign In on mobile.
+      # GOTRUE_EXTERNAL_SKIP_NONCE_CHECK: "true"
+
+      # GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "true"
+      # GOTRUE_SMTP_MAX_FREQUENCY: 1s
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
+      GOTRUE_SMTP_HOST: ${SMTP_HOST}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT}
+      GOTRUE_SMTP_USER: ${SMTP_USER}
+      GOTRUE_SMTP_PASS: ${SMTP_PASS}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME}
+      GOTRUE_MAILER_URLPATHS_INVITE: ${MAILER_URLPATHS_INVITE}
+      GOTRUE_MAILER_URLPATHS_CONFIRMATION: ${MAILER_URLPATHS_CONFIRMATION}
+      GOTRUE_MAILER_URLPATHS_RECOVERY: ${MAILER_URLPATHS_RECOVERY}
+      GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: ${MAILER_URLPATHS_EMAIL_CHANGE}
+
+      GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
+      GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}
+
+      # Uncomment to enable OAuth / social login providers.
+      GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${GOTRUE_EXTERNAL_GOOGLE_ENABLED}
+      GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID}
+      GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOTRUE_EXTERNAL_GOOGLE_SECRET}
+      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI}
+
+      # GOTRUE_EXTERNAL_GITHUB_ENABLED: ${GITHUB_ENABLED}
+      # GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      # GOTRUE_EXTERNAL_GITHUB_SECRET: ${GITHUB_SECRET}
+      # GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: ${API_EXTERNAL_URL}/auth/v1/callback
+
+      # GOTRUE_EXTERNAL_AZURE_ENABLED: ${AZURE_ENABLED}
+      # GOTRUE_EXTERNAL_AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+      # GOTRUE_EXTERNAL_AZURE_SECRET: ${AZURE_SECRET}
+      # GOTRUE_EXTERNAL_AZURE_REDIRECT_URI: ${API_EXTERNAL_URL}/auth/v1/callback
+
+      # Uncomment to configure SMS delivery (phone auth and phone MFA).
+      # GOTRUE_SMS_PROVIDER: ${SMS_PROVIDER}
+      # GOTRUE_SMS_OTP_EXP: ${SMS_OTP_EXP}
+      # GOTRUE_SMS_OTP_LENGTH: ${SMS_OTP_LENGTH}
+      # GOTRUE_SMS_MAX_FREQUENCY: ${SMS_MAX_FREQUENCY}
+      # GOTRUE_SMS_TEMPLATE: ${SMS_TEMPLATE}
+
+      # Twilio credentials (when SMS_PROVIDER=twilio)
+      # GOTRUE_SMS_TWILIO_ACCOUNT_SID: ${SMS_TWILIO_ACCOUNT_SID}
+      # GOTRUE_SMS_TWILIO_AUTH_TOKEN: ${SMS_TWILIO_AUTH_TOKEN}
+      # GOTRUE_SMS_TWILIO_MESSAGE_SERVICE_SID: ${SMS_TWILIO_MESSAGE_SERVICE_SID}
+
+      # Test OTP mappings for development
+      # GOTRUE_SMS_TEST_OTP: ${SMS_TEST_OTP}
+
+      # Uncomment to configure multi-factor authentication (MFA).
+      # GOTRUE_MFA_TOTP_ENROLL_ENABLED: ${MFA_TOTP_ENROLL_ENABLED}
+      # GOTRUE_MFA_TOTP_VERIFY_ENABLED: ${MFA_TOTP_VERIFY_ENABLED}
+      # GOTRUE_MFA_PHONE_ENROLL_ENABLED: ${MFA_PHONE_ENROLL_ENABLED}
+      # GOTRUE_MFA_PHONE_VERIFY_ENABLED: ${MFA_PHONE_VERIFY_ENABLED}
+      # GOTRUE_MFA_MAX_ENROLLED_FACTORS: ${MFA_MAX_ENROLLED_FACTORS}
+
+      # SAML SSO
+      # GOTRUE_SAML_ENABLED: ${SAML_ENABLED}
+      # GOTRUE_SAML_PRIVATE_KEY: ${SAML_PRIVATE_KEY}
+      # GOTRUE_SAML_ALLOW_ENCRYPTED_ASSERTIONS: ${SAML_ALLOW_ENCRYPTED_ASSERTIONS}
+      # GOTRUE_SAML_RELAY_STATE_VALIDITY_PERIOD: ${SAML_RELAY_STATE_VALIDITY_PERIOD}
+      # GOTRUE_SAML_EXTERNAL_URL: ${SAML_EXTERNAL_URL}
+      # GOTRUE_SAML_RATE_LIMIT_ASSERTION: ${SAML_RATE_LIMIT_ASSERTION}
+
+      # Uncomment to enable custom access token hook.
+      # See: https://supabase.com/docs/guides/auth/auth-hooks for
+      # full list of hooks and additional details about custom_access_token_hook
+
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: "pg-functions://postgres/public/custom_access_token_hook"
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_SECRETS: "<standard-base64-secret>"
+
+      # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED: "true"
+      # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/mfa_verification_attempt"
+
+      # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED: "true"
+      # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/password_verification_attempt"
+
+      # GOTRUE_HOOK_SEND_SMS_ENABLED: "false"
+      # GOTRUE_HOOK_SEND_SMS_URI: "pg-functions://postgres/public/custom_access_token_hook"
+      # GOTRUE_HOOK_SEND_SMS_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+
+      # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
+      # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
+      # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+
+  rest:
+    container_name: supabase-rest
+    image: postgrest/postgrest:v14.12
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+      PGRST_DB_ANON_ROLE: anon
+
+      # PostgREST accepts a plain-text symmetric secret, a single JWK, or a JWKS.
+      # For Podman, use either PGRST_JWT_SECRET: ${JWT_SECRET} or
+      # PGRST_JWT_SECRET: ${JWT_JWKS}
+      PGRST_JWT_SECRET: ${JWT_JWKS:-${JWT_SECRET}}
+
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
+      PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY}
+    command:
+      [
+        "postgrest"
+      ]
+
+  realtime:
+    # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
+    container_name: realtime-dev.supabase-realtime
+    image: supabase/realtime:v2.102.3
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sSfL --head -o /dev/null -H \"Authorization: Bearer ${ANON_KEY}\" http://localhost:4000/api/tenants/realtime-dev/health"
+        ]
+      timeout: 5s
+      interval: 30s
+      retries: 3
+      start_period: 10s
+    environment:
+      PORT: 4000
+      DB_HOST: ${POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT}
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB}
+      DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
+      DB_ENC_KEY: supabaserealtime
+
+      # Legacy symmetric HS256 key
+      API_JWT_SECRET: ${JWT_SECRET}
+
+      # JWKS for token verification (EC public + legacy symmetric).
+      # For Podman, use: API_JWT_JWKS: ${JWT_JWKS}
+      #API_JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
+
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: "10000"
+      APP_NAME: realtime
+      SEED_SELF_HOST: "true"
+      RUN_JANITOR: "true"
+      DISABLE_HEALTHCHECK_LOGGING: "true"
+
+  # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
+  storage:
+    container_name: supabase-storage
+    image: supabase/storage-api:v1.60.4
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+      rest:
+        condition: service_started
+      imgproxy:
+        condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://storage:5000/status"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+      start_period: 10s
+    environment:
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      POSTGREST_URL: http://rest:3000
+
+      # Legacy symmetric HS256 key
+      AUTH_JWT_SECRET: ${JWT_SECRET}
+
+      # JWKS for token verification (EC public + legacy symmetric).
+      # For Podman, use: JWT_JWKS: ${JWT_JWKS}
+      #JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
+
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
+      FILE_SIZE_LIMIT: 52428800
+      STORAGE_BACKEND: file
+      # S3 bucket when using S3 backend, directory name when using 'file'
+      GLOBAL_S3_BUCKET: ${GLOBAL_S3_BUCKET}
+      # S3 Backend configuration
+      #GLOBAL_S3_ENDPOINT: https://your-s3-endpoint
+      #GLOBAL_S3_PROTOCOL: https
+      #GLOBAL_S3_FORCE_PATH_STYLE: "true"
+      #AWS_ACCESS_KEY_ID: your-access-key-id
+      #AWS_SECRET_ACCESS_KEY: your-secret-access-key
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: ${STORAGE_TENANT_ID}
+      # TODO: https://github.com/supabase/storage-api/issues/55
+      REGION: ${REGION}
+      ENABLE_IMAGE_TRANSFORMATION: "true"
+      IMGPROXY_URL: http://imgproxy:5001
+      # S3 protocol endpoint configuration
+      S3_PROTOCOL_ACCESS_KEY_ID: ${S3_PROTOCOL_ACCESS_KEY_ID}
+      S3_PROTOCOL_ACCESS_KEY_SECRET: ${S3_PROTOCOL_ACCESS_KEY_SECRET}
+    volumes:
+      - ./volumes/storage:/var/lib/storage:z
+
+  imgproxy:
+    container_name: supabase-imgproxy
+    image: darthsim/imgproxy:v3.30.1
+    restart: unless-stopped
+    volumes:
+      - ./volumes/storage:/var/lib/storage:z
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "imgproxy",
+          "health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    environment:
+      IMGPROXY_BIND: ":5001"
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
+      IMGPROXY_USE_ETAG: "true"
+      IMGPROXY_AUTO_WEBP: ${IMGPROXY_AUTO_WEBP}
+      IMGPROXY_MAX_SRC_RESOLUTION: 16.8
+
+  meta:
+    container_name: supabase-meta
+    image: supabase/postgres-meta:v0.96.6
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: ${POSTGRES_HOST}
+      PG_META_DB_PORT: ${POSTGRES_PORT}
+      PG_META_DB_NAME: ${POSTGRES_DB}
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      CRYPTO_KEY: ${PG_META_CRYPTO_KEY}
+
+  functions:
+    container_name: supabase-edge-functions
+    image: supabase/edge-runtime:v1.74.0
+    restart: unless-stopped
+    volumes:
+      - ./volumes/functions:/home/deno/functions:z
+      - deno-cache:/root/.cache/deno
+    depends_on:
+      kong:
+        condition: service_healthy
+    environment:
+      # Legacy symmetric HS256 key
+      JWT_SECRET: ${JWT_SECRET}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      # Legacy API keys (HS256-signed JWTs)
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      # New opaque API keys
+      SUPABASE_PUBLISHABLE_KEYS: "{\"default\":\"${SUPABASE_PUBLISHABLE_KEY:-}\"}"
+      SUPABASE_SECRET_KEYS: "{\"default\":\"${SUPABASE_SECRET_KEY:-}\"}"
+      SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      # TODO: Allow configuring VERIFY_JWT per function.
+      VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT}"
+    command:
+      [
+        "start",
+        "--main-service",
+        "/home/deno/functions/main"
+      ]
+
+  # Comment out everything below this point if you are using an external Postgres database
+  db:
+    container_name: supabase-db
+    image: supabase/postgres:15.8.1.085
+    restart: unless-stopped
+    volumes:
+      - ./volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:Z
+      # Must be superuser to create event trigger
+      - ./volumes/db/webhooks.sql:/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql:Z
+      # Must be superuser to alter reserved role
+      - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:Z
+      # Initialize the database settings with JWT_SECRET and JWT_EXP
+      - ./volumes/db/jwt.sql:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:Z
+      # PGDATA directory is persisted between restarts
+      - ./volumes/db/data:/var/lib/postgresql/data:Z
+      # Changes required for internal supabase data such as _analytics
+      - ./volumes/db/_supabase.sql:/docker-entrypoint-initdb.d/migrations/97-_supabase.sql:Z
+      # Changes required for Analytics support
+      - ./volumes/db/logs.sql:/docker-entrypoint-initdb.d/migrations/99-logs.sql:Z
+      # Changes required for Pooler support
+      - ./volumes/db/pooler.sql:/docker-entrypoint-initdb.d/migrations/99-pooler.sql:Z
+      # Use named volume to persist pgsodium decryption key between restarts
+      - db-config:/etc/postgresql-custom
+    healthcheck:
+      test:
+        [
+        "CMD",
+        "pg_isready",
+        "-U",
+        "postgres",
+        "-h",
+        "localhost"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    environment:
+      POSTGRES_HOST: /var/run/postgresql
+      PGPORT: ${POSTGRES_PORT}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB}
+      POSTGRES_DB: ${POSTGRES_DB}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXP: ${JWT_EXPIRY}
+    command:
+      [
+        "postgres",
+        "-c",
+        "config_file=/etc/postgresql/postgresql.conf",
+        "-c",
+        "log_min_messages=fatal" # prevents Realtime polling queries from appearing in logs
+      ]
+
+  # Update the DATABASE_URL if you are using an external Postgres database
+  supavisor:
+    container_name: supabase-pooler
+    image: supabase/supavisor:2.9.5
+    restart: unless-stopped
+    ports:
+      - ${POSTGRES_PORT}:5432
+      - ${POOLER_PROXY_PORT_TRANSACTION}:6543
+    volumes:
+      - ./volumes/pooler/pooler.exs:/etc/pooler/pooler.exs:ro,z
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-sSfL",
+          "--head",
+          "-o",
+          "/dev/null",
+          "http://127.0.0.1:4000/api/health"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_URL: ecto://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/_supabase
+      CLUSTER_POSTGRES: "true"
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      VAULT_ENC_KEY: ${VAULT_ENC_KEY}
+      API_JWT_SECRET: ${JWT_SECRET}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
+      REGION: local
+      ERL_AFLAGS: -proto_dist inet_tcp
+      POOLER_TENANT_ID: ${POOLER_TENANT_ID}
+      POOLER_DEFAULT_POOL_SIZE: ${POOLER_DEFAULT_POOL_SIZE}
+      POOLER_MAX_CLIENT_CONN: ${POOLER_MAX_CLIENT_CONN}
+      POOLER_POOL_MODE: transaction
+      DB_POOL_SIZE: ${POOLER_DB_POOL_SIZE}
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "/app/bin/migrate && /app/bin/supavisor eval \"$$(cat /etc/pooler/pooler.exs)\" && /app/bin/server"
+      ]
+
+networks:
+  npm-network:
+    external: true
+
+volumes:
+  db-config:
+  deno-cache:

--- a/infra/supabase/volumes/api/kong-entrypoint.sh
+++ b/infra/supabase/volumes/api/kong-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Custom entrypoint for Kong that builds Lua expressions for request-transformer
+# and performs environment variable substitution in the declarative config.
+
+# Build Lua expressions for translating opaque API keys to asymmetric JWTs.
+# When opaque keys are not configured (empty env vars), expressions fall through
+# to legacy-only behavior - just passing apikey as-is.
+#
+# Full expression logic (when opaque keys are configured):
+#   1. If Authorization header exists and is NOT an sb_ key -> pass through (user session JWT)
+#   2. If apikey matches secret key -> set service_role asymmetric JWT internal "API key"
+#   3. If apikey matches publishable key -> set anon asymmetric JWT internal "API key"
+#   4. Fallback: pass apikey as-is (legacy HS256 JWT)
+
+if [ -n "$SUPABASE_SECRET_KEY" ] && [ -n "$SUPABASE_PUBLISHABLE_KEY" ]; then
+    # Opaque keys configured -> full translation expressions
+    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or (headers.apikey == '$SUPABASE_SECRET_KEY' and 'Bearer $SERVICE_ROLE_KEY_ASYMMETRIC') or (headers.apikey == '$SUPABASE_PUBLISHABLE_KEY' and 'Bearer $ANON_KEY_ASYMMETRIC') or headers.apikey)"
+
+    # Realtime WebSocket: reads from query_params.apikey (supabase-js sends apikey
+    # via query string), outputs to x-api-key header which Realtime checks first.
+    export LUA_RT_WS_EXPR="\$((query_params.apikey == '$SUPABASE_SECRET_KEY' and '$SERVICE_ROLE_KEY_ASYMMETRIC') or (query_params.apikey == '$SUPABASE_PUBLISHABLE_KEY' and '$ANON_KEY_ASYMMETRIC') or query_params.apikey)"
+else
+    # Legacy API keys, not sb_ API keys -> pass apikey through unchanged
+    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or headers.apikey)"
+    export LUA_RT_WS_EXPR="\$(query_params.apikey)"
+fi
+
+# Substitute environment variables in the Kong declarative config.
+# Uses awk instead of eval/echo to preserve YAML quoting (eval strips double
+# quotes, breaking "Header: value" patterns that YAML parses as mappings).
+awk '{
+  result = ""
+  rest = $0
+  while (match(rest, /\$[A-Za-z_][A-Za-z_0-9]*/)) {
+    varname = substr(rest, RSTART + 1, RLENGTH - 1)
+    if (varname in ENVIRON) {
+      result = result substr(rest, 1, RSTART - 1) ENVIRON[varname]
+    } else {
+      result = result substr(rest, 1, RSTART + RLENGTH - 1)
+    }
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  print result rest
+}' /home/kong/temp.yml > "$KONG_DECLARATIVE_CONFIG"
+
+# Remove empty key-auth credentials (unconfigured opaque keys)
+sed -i '/^[[:space:]]*- key:[[:space:]]*$/d' "$KONG_DECLARATIVE_CONFIG"
+
+exec /entrypoint.sh kong docker-start

--- a/infra/supabase/volumes/api/kong.yml
+++ b/infra/supabase/volumes/api/kong.yml
@@ -1,0 +1,408 @@
+_format_version: '2.1'
+_transform: true
+
+###
+### Consumers / Users
+###
+consumers:
+  - username: DASHBOARD
+  - username: anon
+    keyauth_credentials:
+      - key: $SUPABASE_ANON_KEY
+      - key: $SUPABASE_PUBLISHABLE_KEY
+  - username: service_role
+    keyauth_credentials:
+      - key: $SUPABASE_SERVICE_KEY
+      - key: $SUPABASE_SECRET_KEY
+
+###
+### Access Control List
+###
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+###
+### Dashboard credentials
+###
+basicauth_credentials:
+  - consumer: DASHBOARD
+    username: '$DASHBOARD_USERNAME'
+    password: '$DASHBOARD_PASSWORD'
+
+###
+### API Routes
+###
+services:
+  ## Open Auth routes
+  - name: auth-v1-open
+    _comment: 'Auth: /auth/v1/verify* -> http://auth:9999/verify*'
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
+  - name: auth-v1-open-callback
+    _comment: 'Auth: /auth/v1/callback* -> http://auth:9999/callback*'
+    url: http://auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths:
+          - /auth/v1/callback
+    plugins:
+      - name: cors
+  - name: auth-v1-open-authorize
+    _comment: 'Auth: /auth/v1/authorize* -> http://auth:9999/authorize*'
+    url: http://auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths:
+          - /auth/v1/authorize
+    plugins:
+      - name: cors
+  - name: auth-v1-open-jwks
+    _comment: 'Auth: /auth/v1/.well-known/jwks.json -> http://auth:9999/.well-known/jwks.json'
+    url: http://auth:9999/.well-known/jwks.json
+    routes:
+      - name: auth-v1-open-jwks
+        strip_path: true
+        paths:
+          - /auth/v1/.well-known/jwks.json
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-sso-acs
+    url: "http://auth:9999/sso/saml/acs"
+    routes:
+      - name: auth-v1-open-sso-acs
+        strip_path: true
+        paths:
+        - /sso/saml/acs
+    plugins:
+      - name: cors
+      
+  - name: auth-v1-open-sso-metadata
+    url: "http://auth:9999/sso/saml/metadata"
+    routes:
+      - name: auth-v1-open-sso-metadata
+        strip_path: true
+        paths:
+        - /sso/saml/metadata
+    plugins:
+      - name: cors
+
+  ## Secure Auth routes
+  - name: auth-v1
+    _comment: 'Auth: /auth/v1/* -> http://auth:9999/*'
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure PostgREST routes
+  - name: rest-v1
+    _comment: 'PostgREST: /rest/v1/* -> http://rest:3000/*'
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure GraphQL routes
+  - name: graphql-v1
+    _comment: 'PostgREST: /graphql/v1/* -> http://rest:3000/rpc/graphql'
+    url: http://rest:3000/rpc/graphql
+    routes:
+      - name: graphql-v1-all
+        strip_path: true
+        paths:
+          - /graphql/v1
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Content-Profile: graphql_public"
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure Realtime routes
+  - name: realtime-v1-ws
+    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
+    url: http://realtime-dev.supabase-realtime:4000/socket
+    protocol: ws
+    routes:
+      - name: realtime-v1-ws
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "x-api-key:$LUA_RT_WS_EXPR"
+          replace:
+            querystring:
+              - "apikey:$LUA_RT_WS_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: realtime-v1-rest
+    _comment: 'Realtime: /realtime/v1/api/* -> http://realtime:4000/api/*'
+    url: http://realtime-dev.supabase-realtime:4000/api
+    protocol: http
+    routes:
+      - name: realtime-v1-rest
+        strip_path: true
+        paths:
+          - /realtime/v1/api
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Storage API endpoint (with Authorization header transformation).
+  ## No key-auth — S3 protocol requests don't carry an apikey header.
+  ##
+  ## The request-transformer translates opaque API keys to asymmetric JWTs
+  ## and passes through existing Authorization headers (user JWTs, AWS SigV4).
+  ## When no Authorization or apikey header is present (S3 presigned URLs),
+  ## the Lua expression evaluates to nil which Kong renders as empty string.
+  ## The post-function strips this empty header so Storage's S3 signature
+  ## verification falls through to query-parameter parsing.
+  - name: storage-v1
+    _comment: 'Storage: /storage/v1/* -> http://storage:5000/*'
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: post-function
+        config:
+          access:
+            - |
+              local auth = kong.request.get_header("authorization")
+              if auth == nil or auth == "" or auth:find("^%s*$") then
+                kong.service.request.clear_header("authorization")
+              end
+
+  ## Edge Functions routes
+  - name: functions-v1
+    _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
+    url: http://functions:9000/
+    read_timeout: 150000
+    routes:
+      - name: functions-v1-all
+        strip_path: true
+        paths:
+          - /functions/v1/
+    plugins:
+      - name: cors
+
+  ## OAuth 2.0 Authorization Server Metadata (RFC 8414)
+  - name: well-known-oauth
+    _comment: 'Auth: /.well-known/oauth-authorization-server -> http://auth:9999/.well-known/oauth-authorization-server'
+    url: http://auth:9999/.well-known/oauth-authorization-server
+    routes:
+      - name: well-known-oauth
+        strip_path: true
+        paths:
+          - /.well-known/oauth-authorization-server
+    plugins:
+      - name: cors
+
+  ## Analytics routes
+  ## Not used - Studio and Vector talk directly to analytics via Docker networking.
+  ## If external access is needed, add routes with key-auth matching Logflare's x-api-key auth.
+  # - name: analytics-v1-api
+  #   _comment: 'Analytics: /analytics/v1/api/endpoints/* -> http://logflare:4000/api/endpoints/*'
+  #   url: http://analytics:4000/api/endpoints
+  #   routes:
+  #     - name: analytics-v1-api
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1/api/endpoints/
+  # - name: analytics-v1
+  #   _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
+  #   url: http://analytics:4000/
+  #   routes:
+  #     - name: dashboard-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1
+  #   plugins:
+  #     - name: cors
+  #     - name: basic-auth
+  #       config:
+  #         hide_credentials: true
+
+  ## Secure Database routes
+  - name: meta
+    _comment: 'pg-meta: /pg/* -> http://pg-meta:8080/*'
+    url: http://meta:8080/
+    routes:
+      - name: meta-all
+        strip_path: true
+        paths:
+          - /pg/
+    plugins:
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+
+  ## Block access to /api/mcp
+  - name: mcp-blocker
+    _comment: 'Block direct access to /api/mcp'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp-blocker-route
+        strip_path: true
+        paths:
+          - /api/mcp
+    plugins:
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+
+  ## MCP endpoint - local access
+  - name: mcp
+    _comment: 'MCP: /mcp -> http://studio:3000/api/mcp (local access)'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp
+        strip_path: true
+        paths:
+          - /mcp
+    plugins:
+      # Block access to /mcp by default
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+      # Enable local access (danger zone!)
+      # 1. Comment out the 'request-termination' section above
+      # 2. Uncomment the entire section below, including 'deny'
+      # 3. Add your local IPs to the 'allow' list
+      #- name: cors
+      #- name: ip-restriction
+      #  config:
+      #    allow:
+      #      - 127.0.0.1
+      #      - ::1
+      #    deny: []
+
+  ## Protected Dashboard - catch all remaining routes
+  - name: dashboard
+    _comment: 'Studio: /* -> http://studio:3000/*'
+    url: http://studio:3000/
+    routes:
+      - name: dashboard-all
+        strip_path: true
+        paths:
+          - /
+    plugins:
+      - name: cors
+      - name: basic-auth
+        config:
+          hide_credentials: true

--- a/infra/supabase/volumes/db/_supabase.sql
+++ b/infra/supabase/volumes/db/_supabase.sql
@@ -1,0 +1,3 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+CREATE DATABASE _supabase WITH OWNER :pguser;

--- a/infra/supabase/volumes/db/jwt.sql
+++ b/infra/supabase/volumes/db/jwt.sql
@@ -1,0 +1,5 @@
+\set jwt_secret `echo "$JWT_SECRET"`
+\set jwt_exp `echo "$JWT_EXP"`
+
+ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
+ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';

--- a/infra/supabase/volumes/db/logs.sql
+++ b/infra/supabase/volumes/db/logs.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _analytics;
+alter schema _analytics owner to :pguser;
+\c postgres

--- a/infra/supabase/volumes/db/pooler.sql
+++ b/infra/supabase/volumes/db/pooler.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _supavisor;
+alter schema _supavisor owner to :pguser;
+\c postgres

--- a/infra/supabase/volumes/db/realtime.sql
+++ b/infra/supabase/volumes/db/realtime.sql
@@ -1,0 +1,4 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+create schema if not exists _realtime;
+alter schema _realtime owner to :pguser;

--- a/infra/supabase/volumes/db/roles.sql
+++ b/infra/supabase/volumes/db/roles.sql
@@ -1,0 +1,8 @@
+-- NOTE: change to your own passwords for production environments
+\set pgpass `echo "$POSTGRES_PASSWORD"`
+
+ALTER USER authenticator WITH PASSWORD :'pgpass';
+ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_functions_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_storage_admin WITH PASSWORD :'pgpass';

--- a/infra/supabase/volumes/db/webhooks.sql
+++ b/infra/supabase/volumes/db/webhooks.sql
@@ -1,0 +1,208 @@
+BEGIN;
+  -- Create pg_net extension
+  CREATE EXTENSION IF NOT EXISTS pg_net SCHEMA extensions;
+  -- Create supabase_functions schema
+  CREATE SCHEMA supabase_functions AUTHORIZATION supabase_admin;
+  GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+  -- supabase_functions.migrations definition
+  CREATE TABLE supabase_functions.migrations (
+    version text PRIMARY KEY,
+    inserted_at timestamptz NOT NULL DEFAULT NOW()
+  );
+  -- Initial supabase_functions migration
+  INSERT INTO supabase_functions.migrations (version) VALUES ('initial');
+  -- supabase_functions.hooks definition
+  CREATE TABLE supabase_functions.hooks (
+    id bigserial PRIMARY KEY,
+    hook_table_id integer NOT NULL,
+    hook_name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    request_id bigint
+  );
+  CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks USING btree (request_id);
+  CREATE INDEX supabase_functions_hooks_h_table_id_h_name_idx ON supabase_functions.hooks USING btree (hook_table_id, hook_name);
+  COMMENT ON TABLE supabase_functions.hooks IS 'Supabase Functions Hooks: Audit trail for triggered hooks.';
+  CREATE FUNCTION supabase_functions.http_request()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      request_id bigint;
+      payload jsonb;
+      url text := TG_ARGV[0]::text;
+      method text := TG_ARGV[1]::text;
+      headers jsonb DEFAULT '{}'::jsonb;
+      params jsonb DEFAULT '{}'::jsonb;
+      timeout_ms integer DEFAULT 1000;
+    BEGIN
+      IF url IS NULL OR url = 'null' THEN
+        RAISE EXCEPTION 'url argument is missing';
+      END IF;
+
+      IF method IS NULL OR method = 'null' THEN
+        RAISE EXCEPTION 'method argument is missing';
+      END IF;
+
+      IF TG_ARGV[2] IS NULL OR TG_ARGV[2] = 'null' THEN
+        headers = '{"Content-Type": "application/json"}'::jsonb;
+      ELSE
+        headers = TG_ARGV[2]::jsonb;
+      END IF;
+
+      IF TG_ARGV[3] IS NULL OR TG_ARGV[3] = 'null' THEN
+        params = '{}'::jsonb;
+      ELSE
+        params = TG_ARGV[3]::jsonb;
+      END IF;
+
+      IF TG_ARGV[4] IS NULL OR TG_ARGV[4] = 'null' THEN
+        timeout_ms = 1000;
+      ELSE
+        timeout_ms = TG_ARGV[4]::integer;
+      END IF;
+
+      CASE
+        WHEN method = 'GET' THEN
+          SELECT http_get INTO request_id FROM net.http_get(
+            url,
+            params,
+            headers,
+            timeout_ms
+          );
+        WHEN method = 'POST' THEN
+          payload = jsonb_build_object(
+            'old_record', OLD,
+            'record', NEW,
+            'type', TG_OP,
+            'table', TG_TABLE_NAME,
+            'schema', TG_TABLE_SCHEMA
+          );
+
+          SELECT http_post INTO request_id FROM net.http_post(
+            url,
+            payload,
+            params,
+            headers,
+            timeout_ms
+          );
+        ELSE
+          RAISE EXCEPTION 'method argument % is invalid', method;
+      END CASE;
+
+      INSERT INTO supabase_functions.hooks
+        (hook_table_id, hook_name, request_id)
+      VALUES
+        (TG_RELID, TG_NAME, request_id);
+
+      RETURN NEW;
+    END
+  $function$;
+  -- Supabase super admin
+  DO
+  $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = 'supabase_functions_admin'
+    )
+    THEN
+      CREATE USER supabase_functions_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+    END IF;
+  END
+  $$;
+  GRANT ALL PRIVILEGES ON SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  ALTER USER supabase_functions_admin SET search_path = "supabase_functions";
+  ALTER table "supabase_functions".migrations OWNER TO supabase_functions_admin;
+  ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
+  ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
+  GRANT supabase_functions_admin TO postgres;
+  -- Remove unused supabase_pg_net_admin role
+  DO
+  $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = 'supabase_pg_net_admin'
+    )
+    THEN
+      REASSIGN OWNED BY supabase_pg_net_admin TO supabase_admin;
+      DROP OWNED BY supabase_pg_net_admin;
+      DROP ROLE supabase_pg_net_admin;
+    END IF;
+  END
+  $$;
+  -- pg_net grants when extension is already enabled
+  DO
+  $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_extension
+      WHERE extname = 'pg_net'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END
+  $$;
+  -- Event trigger for pg_net
+  CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access()
+  RETURNS event_trigger
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_event_trigger_ddl_commands() AS ev
+      JOIN pg_extension AS ext
+      ON ev.objid = ext.oid
+      WHERE ext.extname = 'pg_net'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END;
+  $$;
+  COMMENT ON FUNCTION extensions.grant_pg_net_access IS 'Grants access to pg_net';
+  DO
+  $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_event_trigger
+      WHERE evtname = 'issue_pg_net_access'
+    ) THEN
+      CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+      EXECUTE PROCEDURE extensions.grant_pg_net_access();
+    END IF;
+  END
+  $$;
+  INSERT INTO supabase_functions.migrations (version) VALUES ('20210809183423_update_grants');
+  ALTER function supabase_functions.http_request() SECURITY DEFINER;
+  ALTER function supabase_functions.http_request() SET search_path = supabase_functions;
+  REVOKE ALL ON FUNCTION supabase_functions.http_request() FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION supabase_functions.http_request() TO postgres, anon, authenticated, service_role;
+COMMIT;

--- a/infra/supabase/volumes/functions/hello/index.ts
+++ b/infra/supabase/volumes/functions/hello/index.ts
@@ -1,0 +1,14 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+Deno.serve(async () => {
+  return new Response(
+    `"Hello from Edge Functions!"`,
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+// To invoke:
+// curl 'http://localhost:<KONG_HTTP_PORT>/functions/v1/hello' \
+//   --header 'Authorization: Bearer <anon/service_role API key>'

--- a/infra/supabase/volumes/functions/main/index.ts
+++ b/infra/supabase/volumes/functions/main/index.ts
@@ -1,0 +1,168 @@
+import * as jose from 'https://deno.land/x/jose@v4.14.4/index.ts'
+
+console.log('main function started')
+
+const JWT_SECRET = Deno.env.get('JWT_SECRET')
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
+const VERIFY_JWT = Deno.env.get('VERIFY_JWT') === 'true'
+
+// Create JWKS for ES256/RS256 tokens (newer tokens)
+let SUPABASE_JWT_KEYS: ReturnType<typeof jose.createRemoteJWKSet> | null = null
+if (SUPABASE_URL) {
+  try {
+    SUPABASE_JWT_KEYS = jose.createRemoteJWKSet(
+      new URL('/auth/v1/.well-known/jwks.json', SUPABASE_URL)
+    )
+  } catch (e) {
+    console.error('Failed to fetch JWKS from SUPABASE_URL:', e)
+  }
+}
+
+/**
+ * Extract JWT token from Authorization header
+ * 
+ * Parses the Authorization header to extract the Bearer token.
+ * Expects format: "Bearer <token>"
+ * 
+ * @param req - The HTTP request object
+ * @returns The JWT token string
+ * @throws Error if Authorization header is missing or malformed
+ */
+function getAuthToken(req: Request) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) {
+    throw new Error('Missing authorization header')
+  }
+  const [bearer, token] = authHeader.split(' ')
+  if (bearer !== 'Bearer') {
+    throw new Error(`Auth header is not 'Bearer {token}'`)
+  }
+  return token
+}
+
+async function isValidLegacyJWT(jwt: string): Promise<boolean> {
+  if (!JWT_SECRET) {
+    console.error('JWT_SECRET not available for HS256 token verification')
+    return false
+  }
+
+  const encoder = new TextEncoder();
+  const secretKey = encoder.encode(JWT_SECRET)
+
+  try {
+    await jose.jwtVerify(jwt, secretKey);
+  } catch (e) {
+    console.error('Symmetric Legacy JWT verification error', e);
+    return false;
+  }
+  return true;
+}
+
+async function isValidJWT(jwt: string): Promise<boolean> {
+  if (!SUPABASE_JWT_KEYS) {
+    console.error('JWKS not available for ES256/RS256 token verification')
+    return false
+  }
+
+  try {
+    await jose.jwtVerify(jwt, SUPABASE_JWT_KEYS)
+  } catch (e) {
+    console.error('Asymmetric JWT verification error', e);
+    return false
+  }
+
+  return true;
+}
+
+/**
+ * Verify JWT token, handling both legacy (HS256) and newer (ES256/RS256) algorithms
+ * 
+ * This function automatically detects the algorithm used in the token and applies
+ * the appropriate verification method:
+ * - HS256: Uses JWT_SECRET (symmetric key)
+ * - ES256/RS256: Uses JWKS endpoint (asymmetric public keys)
+ * 
+ * This fix ensures compatibility with both legacy tokens and newer asymmetric tokens,
+ * resolving the "Key for the ES256 algorithm must be of type CryptoKey" error.
+ * 
+ * @param jwt - The JWT token string to verify
+ * @returns Promise resolving to true if verification succeeds, false otherwise
+ */
+async function isValidHybridJWT(jwt: string): Promise<boolean> {
+  const { alg: jwtAlgorithm } = jose.decodeProtectedHeader(jwt)
+
+  if (jwtAlgorithm === 'HS256') {
+    console.log(`Legacy token type detected, attempting ${jwtAlgorithm} verification.`)
+
+    return await isValidLegacyJWT(jwt)
+  }
+
+  if (jwtAlgorithm === 'ES256' || jwtAlgorithm === 'RS256') {
+    return await isValidJWT(jwt)
+  }
+
+  return false;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'OPTIONS' && VERIFY_JWT) {
+    try {
+      const token = getAuthToken(req)
+      const isValidJWT = await isValidHybridJWT(token);
+
+      if (!isValidJWT) {
+        return new Response(JSON.stringify({ msg: 'Invalid JWT' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    } catch (e) {
+      console.error(e)
+      return new Response(JSON.stringify({ msg: e.toString() }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+  }
+
+  const url = new URL(req.url)
+  const { pathname } = url
+  const path_parts = pathname.split('/')
+  const service_name = path_parts[1]
+
+  if (!service_name || service_name === '') {
+    const error = { msg: 'missing function name in request' }
+    return new Response(JSON.stringify(error), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const servicePath = `/home/deno/functions/${service_name}`
+  console.error(`serving the request with ${servicePath}`)
+
+  const memoryLimitMb = 150
+  const workerTimeoutMs = 1 * 60 * 1000
+  const noModuleCache = false
+  const importMapPath = null
+  const envVarsObj = Deno.env.toObject()
+  const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]])
+
+  try {
+    const worker = await EdgeRuntime.userWorkers.create({
+      servicePath,
+      memoryLimitMb,
+      workerTimeoutMs,
+      noModuleCache,
+      importMapPath,
+      envVars,
+    })
+    return await worker.fetch(req)
+  } catch (e) {
+    const error = { msg: e.toString() }
+    return new Response(JSON.stringify(error), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/infra/supabase/volumes/pooler/pooler.exs
+++ b/infra/supabase/volumes/pooler/pooler.exs
@@ -1,0 +1,30 @@
+{:ok, _} = Application.ensure_all_started(:supavisor)
+
+{:ok, version} =
+  case Supavisor.Repo.query!("select version()") do
+    %{rows: [[ver]]} -> Supavisor.Helpers.parse_pg_version(ver)
+    _ -> nil
+  end
+
+params = %{
+  "external_id" => System.get_env("POOLER_TENANT_ID"),
+  "db_host" => System.get_env("POSTGRES_HOST") || "db",
+  "db_port" => System.get_env("POSTGRES_PORT"),
+  "db_database" => System.get_env("POSTGRES_DB"),
+  "require_user" => false,
+  "auth_query" => "SELECT * FROM pgbouncer.get_auth($1)",
+  "default_max_clients" => System.get_env("POOLER_MAX_CLIENT_CONN"),
+  "default_pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+  "default_parameter_status" => %{"server_version" => version},
+  "users" => [%{
+    "db_user" => "pgbouncer",
+    "db_password" => System.get_env("POSTGRES_PASSWORD"),
+    "mode_type" => System.get_env("POOLER_POOL_MODE"),
+    "pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+    "is_manager" => true
+  }]
+}
+
+if !Supavisor.Tenants.get_tenant_by_external_id(params["external_id"]) do
+  {:ok, _} = Supavisor.Tenants.create_tenant(params)
+end

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,10 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "blog-supabase.jongchoi.com",
+      },
+      {
+        protocol: "https",
         hostname: "loremflickr.com",
       },
     ],

--- a/public/tutorials/8-supabase-self-hosting.md
+++ b/public/tutorials/8-supabase-self-hosting.md
@@ -1,0 +1,490 @@
+# Supabase Self-Hosting 이전 가이드
+
+이 문서는 기존 Supabase Cloud 프로젝트를 `blog-supabase.jongchoi.com`에서 동작하는 self-hosted Supabase로 옮기기 위한 작업 노트이다.
+
+기존 `public/tutorials/8-gemma4.md`는 Gemma/Ollama 전환 메모로 그대로 두고, 이 문서는 Supabase self-hosting만 따로 다룬다.
+
+## 1. 목표
+
+이번 이전의 목표는 아래와 같다.
+
+1. Supabase API, Auth, Storage, Studio를 Docker Compose로 띄운다.
+2. 공개 주소는 `https://blog-supabase.jongchoi.com`으로 사용한다.
+3. 블로그 앱 주소는 기존처럼 `https://blog.jongchoi.com`을 유지한다.
+4. Google OAuth 로그인 후 블로그 앱의 `/callback`으로 돌아오게 만든다.
+5. Storage는 MinIO S3 backend를 사용한다.
+6. 기존 Cloud Supabase의 DB와 Storage 파일을 self-hosted Supabase로 옮긴다.
+
+이 프로젝트에서는 이를 위해 아래 파일들을 추가했다.
+
+```text
+infra/
+└─ supabase/
+   ├─ compose.yaml
+   ├─ compose.minio.yaml
+   ├─ .env.example
+   ├─ README.md
+   └─ volumes/
+
+scripts/
+└─ supabase/
+   ├─ dump.sh
+   ├─ restore.sh
+   └─ sync-storage.sh
+```
+
+## 2. 구성 개요
+
+`infra/supabase/compose.yaml`은 Supabase 공식 Docker self-host compose를 기반으로 한다.
+
+주요 서비스는 아래와 같다.
+
+- `kong`: 외부 요청을 Auth, REST, Storage, Studio 등으로 라우팅하는 API gateway
+- `auth`: Supabase Auth, Google OAuth 처리를 담당
+- `rest`: PostgREST API
+- `storage`: Supabase Storage API
+- `db`: PostgreSQL
+- `supavisor`: DB pooler
+- `studio`: Supabase Dashboard
+- `realtime`: Realtime 서버
+- `functions`: Edge Functions 런타임
+
+`infra/supabase/compose.minio.yaml`은 Storage backend를 MinIO로 바꾸는 override 파일이다.
+
+```yaml
+storage:
+  environment:
+    STORAGE_BACKEND: s3
+    GLOBAL_S3_ENDPOINT: http://minio:9000
+    GLOBAL_S3_PROTOCOL: http
+    GLOBAL_S3_FORCE_PATH_STYLE: true
+```
+
+Next.js 앱 입장에서는 Storage가 로컬 파일인지 MinIO인지 신경 쓰지 않는다. 앱은 계속 Supabase URL만 호출한다.
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://blog-supabase.jongchoi.com
+```
+
+## 3. 환경변수 준비
+
+먼저 예시 env를 실제 env로 복사한다.
+
+```bash
+cp infra/supabase/.env.example infra/supabase/.env
+```
+
+`infra/supabase/.env`에서 반드시 바꿔야 하는 값은 아래와 같다.
+
+- `POSTGRES_PASSWORD`
+- `JWT_SECRET`
+- `ANON_KEY`
+- `SERVICE_ROLE_KEY`
+- `DASHBOARD_USERNAME`
+- `DASHBOARD_PASSWORD`
+- `SECRET_KEY_BASE`
+- `VAULT_ENC_KEY`
+- `PG_META_CRYPTO_KEY`
+- `S3_PROTOCOL_ACCESS_KEY_ID`
+- `S3_PROTOCOL_ACCESS_KEY_SECRET`
+- `MINIO_ROOT_USER`
+- `MINIO_ROOT_PASSWORD`
+- `GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID`
+- `GOTRUE_EXTERNAL_GOOGLE_SECRET`
+
+도메인 관련 값은 아래 기준으로 맞춘다.
+
+```env
+SITE_URL=https://blog.jongchoi.com
+API_EXTERNAL_URL=https://blog-supabase.jongchoi.com
+SUPABASE_PUBLIC_URL=https://blog-supabase.jongchoi.com
+ADDITIONAL_REDIRECT_URLS=https://blog.jongchoi.com/callback,http://localhost:3000/callback
+```
+
+각 값의 의미는 다음과 같다.
+
+- `SITE_URL`: Auth가 기본적으로 되돌려보낼 앱 주소
+- `API_EXTERNAL_URL`: Auth callback과 이메일 링크 등에 사용되는 Supabase 외부 주소
+- `SUPABASE_PUBLIC_URL`: Studio와 client가 인식하는 Supabase 공개 주소
+- `ADDITIONAL_REDIRECT_URLS`: OAuth 이후 허용되는 추가 redirect 주소
+
+## 4. Docker Compose 실행
+
+Nginx Proxy Manager를 사용할 것이므로, `supabase-kong` 컨테이너를 `npm-network`에 붙인다.
+
+네트워크가 없다면 먼저 생성한다.
+
+```bash
+docker network create npm-network
+```
+
+Compose 설정이 정상인지 확인한다.
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  config
+```
+
+실행은 아래처럼 한다.
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  up -d
+```
+
+종료는 아래처럼 한다.
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  down
+```
+
+## 5. Nginx Proxy Manager 연결
+
+NPM에서는 `blog-supabase.jongchoi.com`을 Supabase Kong gateway로 보낸다.
+
+설정값은 아래처럼 잡는다.
+
+```text
+Domain Names: blog-supabase.jongchoi.com
+Forward Hostname / IP: supabase-kong
+Forward Port: 8000
+Websockets Support: enabled
+SSL: Let's Encrypt
+```
+
+프록시 연결 후 health endpoint를 확인한다.
+
+```bash
+curl https://blog-supabase.jongchoi.com/auth/v1/health
+```
+
+이 요청이 응답하면 최소한 `NPM -> Kong -> Auth` 경로가 열린 것이다.
+
+## 6. Google OAuth 설정
+
+현재 앱 로그인 코드는 아래 방식으로 동작한다.
+
+```ts
+await supabase.auth.signInWithOAuth({
+  provider: "google",
+  options: { redirectTo: `${window.location.origin}/callback` },
+});
+```
+
+따라서 사용자가 `https://blog.jongchoi.com/login`에서 로그인하면 최종 redirect는 아래 주소가 된다.
+
+```text
+https://blog.jongchoi.com/callback
+```
+
+self-hosted Supabase의 Auth 서버에는 Google OAuth 설정을 넣어야 한다.
+
+```env
+GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
+GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=change-me-google-client-id
+GOTRUE_EXTERNAL_GOOGLE_SECRET=change-me-google-secret
+GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=https://blog-supabase.jongchoi.com/auth/v1/callback
+```
+
+Google Cloud Console에는 아래 redirect URI를 등록한다.
+
+```text
+https://blog-supabase.jongchoi.com/auth/v1/callback
+```
+
+여기서 헷갈리기 쉬운 점은 Google에 등록하는 callback과 앱의 callback이 다르다는 점이다.
+
+- Google OAuth provider callback: `https://blog-supabase.jongchoi.com/auth/v1/callback`
+- 블로그 앱 callback: `https://blog.jongchoi.com/callback`
+
+흐름은 아래와 같다.
+
+```text
+blog.jongchoi.com/login
+-> blog-supabase.jongchoi.com/auth/v1/authorize
+-> Google consent
+-> blog-supabase.jongchoi.com/auth/v1/callback
+-> blog.jongchoi.com/callback
+```
+
+Cloud Supabase에서 가져온 기존 세션 토큰은 새 self-hosted Supabase의 JWT secret과 맞지 않는다. 이전 후 다시 로그인해야 하는 것은 정상이다.
+
+## 7. DB 이전
+
+Cloud Supabase DB는 세 개의 SQL 파일로 나눠 dump한다.
+
+```bash
+CLOUD_DB_URL="postgres://..." scripts/supabase/dump.sh
+```
+
+생성되는 파일은 아래 경로에 저장된다.
+
+```text
+infra/supabase/dumps/latest/
+├─ roles.sql
+├─ schema.sql
+└─ data.sql
+```
+
+세 파일의 역할은 아래처럼 나뉜다.
+
+- `roles.sql`: custom role, 권한 복원
+- `schema.sql`: table, view, function, trigger, index, RLS policy 등 DB 구조 복원
+- `data.sql`: table row, `auth.users`, Storage bucket metadata 등 데이터 복원
+
+공식 restore guide 기준으로 DB dump에 포함되는 것은 아래와 같다.
+
+- public schema
+- table data
+- roles
+- RLS policies
+- database functions
+- triggers
+- views
+- `auth.users`
+- Storage bucket metadata
+
+여기서 주의할 점은 Storage bucket metadata와 Storage 실제 파일은 다르다는 것이다. DB restore로 bucket 정의가 들어와도, 이미지 원본 파일과 object record는 별도 S3/rclone 이전을 통해 맞춰야 한다.
+
+self-hosted DB로 복원한다.
+
+```bash
+scripts/supabase/restore.sh
+```
+
+복원 후에는 source와 self-hosted 인벤토리를 비교한다.
+
+```bash
+scripts/supabase/verify-db.sh
+```
+
+`dump.sh`는 `psql`이 설치되어 있으면 `source-inventory.txt`를 같이 만든다. `verify-db.sh`는 self-hosted DB의 `self-hosted-inventory.txt`를 만들고 둘을 `diff`로 비교한다.
+
+기본적으로 `restore.sh`는 `infra/supabase/.env`를 읽고 아래 형태의 접속 문자열을 만든다.
+
+```text
+postgres://postgres.<POOLER_TENANT_ID>:<POSTGRES_PASSWORD>@blog-supabase.jongchoi.com:5432/postgres
+```
+
+다른 DB 주소를 쓰고 싶다면 직접 넘긴다.
+
+```bash
+SELF_HOSTED_DB_URL="postgres://..." scripts/supabase/restore.sh
+```
+
+이 프로젝트는 `pgvector`를 사용하므로 복원 전후 extension을 확인해야 한다.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+SELECT * FROM pg_extension;
+```
+
+복원 후 특히 확인할 RPC는 아래와 같다.
+
+- `search_posts_hybrid`
+- `search_post_chunks_cosine`
+- `search_posts_with_snippet`
+- `batch_update_orders_for_posts`
+- `batch_update_orders_for_categories`
+- `batch_update_orders_for_subcategories`
+
+DB 복원 후에는 아래 쿼리로 view, function, trigger, policy가 실제로 들어왔는지 확인한다.
+
+```sql
+-- 주요 테이블 확인
+\dt public.*
+
+-- 주요 뷰 확인
+\dv public.*
+
+-- public schema 함수 확인
+select proname
+from pg_proc
+where pronamespace = 'public'::regnamespace
+order by proname;
+
+-- 트리거 확인
+select event_object_table, trigger_name
+from information_schema.triggers
+where trigger_schema = 'public'
+order by event_object_table, trigger_name;
+
+-- RLS policy 확인
+select schemaname, tablename, policyname
+from pg_policies
+where schemaname in ('public', 'storage')
+order by schemaname, tablename, policyname;
+
+-- auth user 데이터 확인
+select count(*) from auth.users;
+
+-- Storage bucket metadata 확인
+select id, name, public
+from storage.buckets
+order by name;
+```
+
+DB dump/restore에 포함되지 않아서 별도로 설정해야 하는 것도 있다.
+
+- JWT secret과 anon/service role key
+- Google OAuth provider 설정
+- SMTP 설정
+- custom domain과 DNS
+- Storage 실제 파일
+- Supabase Edge Functions
+- self-hosted compose/env 설정
+
+## 8. Storage 이전
+
+이 프로젝트의 이미지 bucket 이름은 `image`이다.
+
+Storage는 MinIO backend를 쓰지만, 파일 이전은 Supabase Storage의 S3 protocol endpoint를 통해 진행한다.
+
+Cloud Supabase Dashboard에서 Storage S3 access key를 발급한 뒤 아래처럼 실행한다.
+
+```bash
+PLATFORM_S3_ENDPOINT="https://<project-ref>.supabase.co/storage/v1/s3" \
+PLATFORM_S3_REGION="<cloud-region>" \
+PLATFORM_S3_ACCESS_KEY_ID="<cloud-access-key>" \
+PLATFORM_S3_SECRET_ACCESS_KEY="<cloud-secret-key>" \
+scripts/supabase/sync-storage.sh
+```
+
+기본 bucket은 `image`이다.
+
+```bash
+BUCKET=image scripts/supabase/sync-storage.sh
+```
+
+모든 bucket을 옮기려면 아래처럼 실행한다.
+
+```bash
+BUCKET=all scripts/supabase/sync-storage.sh
+```
+
+중요한 점은 `volumes/storage`에 파일을 직접 복사하지 않는 것이다. Storage는 내부 metadata와 object path를 함께 관리하므로, 공식 문서 기준으로 S3 protocol과 rclone을 통해 옮기는 편이 안전하다.
+
+DB restore가 먼저 끝나면 `storage.buckets` 정의가 이미 들어와 있을 수 있다. 그래도 rclone 전에 self-hosted Studio나 SQL로 `image` bucket이 존재하는지 확인한다.
+
+## 9. 앱 코드 전환
+
+self-hosted Supabase로 바꾸려면 앱의 배포 env를 아래처럼 바꾼다.
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://blog-supabase.jongchoi.com
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<self-host-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<self-host-service-role-key>
+```
+
+이번 작업에서 앱 코드도 두 군데 정리했다.
+
+`next.config.ts`에는 self-hosted Storage 이미지를 허용했다.
+
+```ts
+{
+  protocol: "https",
+  hostname: "blog-supabase.jongchoi.com",
+}
+```
+
+`utils/uploadingUtils.tsx`의 Storage URL은 `NEXT_PUBLIC_SUPABASE_URL` 기반으로 바꿨다.
+
+```ts
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  "https://wknphwqwtywjrfclmhjd.supabase.co";
+const commonImagePath = `${supabaseUrl}/storage/v1/object/public/image`;
+```
+
+이렇게 해두면 Cloud Supabase에서 self-hosted Supabase로 도메인을 바꿔도 이미지 추출 로직이 같은 env를 따라간다.
+
+## 10. Deno 타입 경고
+
+`infra/supabase/volumes/functions/main/index.ts`와 `infra/supabase/volumes/functions/hello/index.ts`는 Supabase Edge Functions용 Deno 코드이다.
+
+Next.js 앱의 TypeScript 환경은 Node/React 기준이므로, VS Code에서 아래 경고가 보일 수 있다.
+
+```text
+'Deno' 이름을 찾을 수 없습니다.ts(2304)
+```
+
+이는 앱 코드 문제가 아니라 런타임 차이 때문에 생기는 경고이다.
+
+`tsconfig.json`에서는 이 폴더를 타입체크 대상에서 제외했다.
+
+```json
+"exclude": ["node_modules", "infra/supabase/volumes/functions"]
+```
+
+따라서 `npx tsc --noEmit`은 통과한다. VS Code가 열린 파일 단위로 경고를 보여주는 경우에는 무시하거나, 나중에 Edge Functions를 실제로 운영할 때 Deno 설정을 별도로 추가하면 된다.
+
+## 11. 검증 체크리스트
+
+Compose 설정 확인:
+
+```bash
+docker compose \
+  -f infra/supabase/compose.yaml \
+  -f infra/supabase/compose.minio.yaml \
+  --env-file infra/supabase/.env \
+  config
+```
+
+Auth health 확인:
+
+```bash
+curl https://blog-supabase.jongchoi.com/auth/v1/health
+```
+
+Storage S3 endpoint 확인:
+
+```bash
+AWS_ACCESS_KEY_ID="$S3_PROTOCOL_ACCESS_KEY_ID" \
+AWS_SECRET_ACCESS_KEY="$S3_PROTOCOL_ACCESS_KEY_SECRET" \
+aws s3 ls \
+  --endpoint-url https://blog-supabase.jongchoi.com/storage/v1/s3 \
+  --region "$REGION" \
+  s3://image
+```
+
+앱에서 확인할 항목은 아래와 같다.
+
+- Google OAuth 로그인
+- `/callback` 세션 교환
+- 게시글 이미지 렌더링
+- 이미지 업로드 API
+- semantic search
+- 추천 게시글 조회
+- admin 페이지 조회
+- RPC 호출
+
+## 12. 커밋하면 안 되는 것
+
+아래 항목은 커밋하지 않는다.
+
+- `infra/supabase/.env`
+- `infra/supabase/dumps/`
+- `infra/supabase/rclone.conf`
+- `infra/supabase/volumes/db/data/`
+- `infra/supabase/volumes/storage/`
+- `infra/supabase/volumes/snippets/`
+
+이 값들은 `.gitignore`에 추가되어 있다.
+
+## 참고 문서
+
+- Supabase Self-Hosting with Docker: https://supabase.com/docs/guides/self-hosting/docker
+- Configure Social Login: https://supabase.com/docs/guides/self-hosting/self-hosted-oauth
+- Configure S3 Storage: https://supabase.com/docs/guides/self-hosting/self-hosted-s3
+- Restore Platform Project: https://supabase.com/docs/guides/self-hosting/restore-from-platform
+- Copy Storage Objects: https://supabase.com/docs/guides/self-hosting/copy-from-platform-s3

--- a/scripts/supabase/dump.sh
+++ b/scripts/supabase/dump.sh
@@ -3,7 +3,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${ENV_FILE:-${REPO_ROOT}/infra/supabase/.env}"
 DUMP_DIR="${DUMP_DIR:-${REPO_ROOT}/infra/supabase/dumps/latest}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
 
 if [[ -z "${CLOUD_DB_URL:-}" ]]; then
   echo "CLOUD_DB_URL is required." >&2

--- a/scripts/supabase/dump.sh
+++ b/scripts/supabase/dump.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DUMP_DIR="${DUMP_DIR:-${REPO_ROOT}/infra/supabase/dumps/latest}"
+
+if [[ -z "${CLOUD_DB_URL:-}" ]]; then
+  echo "CLOUD_DB_URL is required." >&2
+  echo "Example: CLOUD_DB_URL='postgres://...' scripts/supabase/dump.sh" >&2
+  exit 1
+fi
+
+mkdir -p "${DUMP_DIR}"
+
+npx supabase db dump --db-url "${CLOUD_DB_URL}" -f "${DUMP_DIR}/roles.sql" --role-only
+npx supabase db dump --db-url "${CLOUD_DB_URL}" -f "${DUMP_DIR}/schema.sql"
+npx supabase db dump --db-url "${CLOUD_DB_URL}" -f "${DUMP_DIR}/data.sql" --use-copy --data-only
+
+if command -v psql >/dev/null 2>&1; then
+  psql "${CLOUD_DB_URL}" --no-align --tuples-only --set ON_ERROR_STOP=1 > "${DUMP_DIR}/source-inventory.txt" <<'SQL'
+select 'extensions';
+select extname from pg_extension order by extname;
+
+select 'public_tables';
+select tablename from pg_tables where schemaname = 'public' order by tablename;
+
+select 'public_views';
+select viewname from pg_views where schemaname = 'public' order by viewname;
+
+select 'public_functions';
+select proname from pg_proc where pronamespace = 'public'::regnamespace order by proname;
+
+select 'public_triggers';
+select event_object_table || '.' || trigger_name
+from information_schema.triggers
+where trigger_schema = 'public'
+order by event_object_table, trigger_name;
+
+select 'policies';
+select schemaname || '.' || tablename || '.' || policyname
+from pg_policies
+where schemaname in ('public', 'storage')
+order by schemaname, tablename, policyname;
+
+select 'auth_users_count';
+select count(*)::text from auth.users;
+
+select 'storage_buckets';
+select id || ':' || name || ':' || public::text from storage.buckets order by name;
+SQL
+else
+  echo "psql not found; skipped source inventory report." >&2
+fi
+
+echo "Dump files written to ${DUMP_DIR}"

--- a/scripts/supabase/restore.sh
+++ b/scripts/supabase/restore.sh
@@ -23,13 +23,14 @@ done
 if [[ -z "${SELF_HOSTED_DB_URL:-}" ]]; then
   SELF_HOSTED_DB_HOST="${SELF_HOSTED_DB_HOST:-blog-supabase.jongchoi.com}"
   POSTGRES_DB="${POSTGRES_DB:-postgres}"
+  POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 
   if [[ -z "${POSTGRES_PASSWORD:-}" || -z "${POOLER_TENANT_ID:-}" ]]; then
     echo "SELF_HOSTED_DB_URL is required unless POSTGRES_PASSWORD and POOLER_TENANT_ID are set." >&2
     exit 1
   fi
 
-  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:5432/${POSTGRES_DB}"
+  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 fi
 
 psql \

--- a/scripts/supabase/restore.sh
+++ b/scripts/supabase/restore.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${ENV_FILE:-${REPO_ROOT}/infra/supabase/.env}"
+DUMP_DIR="${DUMP_DIR:-${REPO_ROOT}/infra/supabase/dumps/latest}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
+
+for file in roles.sql schema.sql data.sql; do
+  if [[ ! -f "${DUMP_DIR}/${file}" ]]; then
+    echo "Missing ${DUMP_DIR}/${file}" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "${SELF_HOSTED_DB_URL:-}" ]]; then
+  SELF_HOSTED_DB_HOST="${SELF_HOSTED_DB_HOST:-blog-supabase.jongchoi.com}"
+  POSTGRES_DB="${POSTGRES_DB:-postgres}"
+
+  if [[ -z "${POSTGRES_PASSWORD:-}" || -z "${POOLER_TENANT_ID:-}" ]]; then
+    echo "SELF_HOSTED_DB_URL is required unless POSTGRES_PASSWORD and POOLER_TENANT_ID are set." >&2
+    exit 1
+  fi
+
+  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:5432/${POSTGRES_DB}"
+fi
+
+psql \
+  --single-transaction \
+  --variable ON_ERROR_STOP=1 \
+  --file "${DUMP_DIR}/roles.sql" \
+  --file "${DUMP_DIR}/schema.sql" \
+  --command "SET session_replication_role = replica" \
+  --file "${DUMP_DIR}/data.sql" \
+  --dbname "${SELF_HOSTED_DB_URL}"
+
+echo "Restore completed from ${DUMP_DIR}"

--- a/scripts/supabase/sync-storage.sh
+++ b/scripts/supabase/sync-storage.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${ENV_FILE:-${REPO_ROOT}/infra/supabase/.env}"
+BUCKET="${BUCKET:-image}"
+SELF_HOSTED_S3_ENDPOINT="${SELF_HOSTED_S3_ENDPOINT:-https://blog-supabase.jongchoi.com/storage/v1/s3}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
+
+required_vars=(
+  PLATFORM_S3_ENDPOINT
+  PLATFORM_S3_REGION
+  PLATFORM_S3_ACCESS_KEY_ID
+  PLATFORM_S3_SECRET_ACCESS_KEY
+  S3_PROTOCOL_ACCESS_KEY_ID
+  S3_PROTOCOL_ACCESS_KEY_SECRET
+  REGION
+)
+
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "${var} is required." >&2
+    exit 1
+  fi
+done
+
+if ! command -v rclone >/dev/null 2>&1; then
+  echo "rclone is required." >&2
+  exit 1
+fi
+
+RCLONE_CONFIG_FILE="$(mktemp)"
+trap 'rm -f "${RCLONE_CONFIG_FILE}"' EXIT
+
+cat > "${RCLONE_CONFIG_FILE}" <<EOF
+[platform]
+type = s3
+provider = Other
+access_key_id = ${PLATFORM_S3_ACCESS_KEY_ID}
+secret_access_key = ${PLATFORM_S3_SECRET_ACCESS_KEY}
+endpoint = ${PLATFORM_S3_ENDPOINT}
+region = ${PLATFORM_S3_REGION}
+
+[self-hosted]
+type = s3
+provider = Other
+access_key_id = ${S3_PROTOCOL_ACCESS_KEY_ID}
+secret_access_key = ${S3_PROTOCOL_ACCESS_KEY_SECRET}
+endpoint = ${SELF_HOSTED_S3_ENDPOINT}
+region = ${REGION}
+EOF
+
+if [[ "${BUCKET}" == "all" ]]; then
+  while IFS= read -r bucket; do
+    bucket="${bucket%/}"
+    [[ -z "${bucket}" ]] && continue
+    rclone --config "${RCLONE_CONFIG_FILE}" copy "platform:${bucket}" "self-hosted:${bucket}" --progress --transfers "${TRANSFERS:-4}" --checkers "${CHECKERS:-8}"
+  done < <(rclone --config "${RCLONE_CONFIG_FILE}" lsf platform:)
+else
+  rclone --config "${RCLONE_CONFIG_FILE}" copy "platform:${BUCKET}" "self-hosted:${BUCKET}" --progress --transfers "${TRANSFERS:-4}" --checkers "${CHECKERS:-8}"
+fi
+
+echo "Storage sync completed for bucket: ${BUCKET}"

--- a/scripts/supabase/verify-db.sh
+++ b/scripts/supabase/verify-db.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${ENV_FILE:-${REPO_ROOT}/infra/supabase/.env}"
+DUMP_DIR="${DUMP_DIR:-${REPO_ROOT}/infra/supabase/dumps/latest}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is required." >&2
+  exit 1
+fi
+
+if [[ -z "${SELF_HOSTED_DB_URL:-}" ]]; then
+  SELF_HOSTED_DB_HOST="${SELF_HOSTED_DB_HOST:-blog-supabase.jongchoi.com}"
+  POSTGRES_DB="${POSTGRES_DB:-postgres}"
+
+  if [[ -z "${POSTGRES_PASSWORD:-}" || -z "${POOLER_TENANT_ID:-}" ]]; then
+    echo "SELF_HOSTED_DB_URL is required unless POSTGRES_PASSWORD and POOLER_TENANT_ID are set." >&2
+    exit 1
+  fi
+
+  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:5432/${POSTGRES_DB}"
+fi
+
+REPORT_FILE="${REPORT_FILE:-${DUMP_DIR}/self-hosted-inventory.txt}"
+mkdir -p "$(dirname "${REPORT_FILE}")"
+
+psql "${SELF_HOSTED_DB_URL}" --no-align --tuples-only --set ON_ERROR_STOP=1 > "${REPORT_FILE}" <<'SQL'
+select 'extensions';
+select extname from pg_extension order by extname;
+
+select 'public_tables';
+select tablename from pg_tables where schemaname = 'public' order by tablename;
+
+select 'public_views';
+select viewname from pg_views where schemaname = 'public' order by viewname;
+
+select 'public_functions';
+select proname from pg_proc where pronamespace = 'public'::regnamespace order by proname;
+
+select 'public_triggers';
+select event_object_table || '.' || trigger_name
+from information_schema.triggers
+where trigger_schema = 'public'
+order by event_object_table, trigger_name;
+
+select 'policies';
+select schemaname || '.' || tablename || '.' || policyname
+from pg_policies
+where schemaname in ('public', 'storage')
+order by schemaname, tablename, policyname;
+
+select 'auth_users_count';
+select count(*)::text from auth.users;
+
+select 'storage_buckets';
+select id || ':' || name || ':' || public::text from storage.buckets order by name;
+SQL
+
+echo "Self-hosted inventory written to ${REPORT_FILE}"
+
+if [[ -f "${DUMP_DIR}/source-inventory.txt" ]]; then
+  if diff -u "${DUMP_DIR}/source-inventory.txt" "${REPORT_FILE}"; then
+    echo "Source and self-hosted inventories match."
+  else
+    echo "Inventory mismatch detected. Review the diff above." >&2
+    exit 1
+  fi
+else
+  echo "No source inventory found at ${DUMP_DIR}/source-inventory.txt; skipped diff."
+fi

--- a/scripts/supabase/verify-db.sh
+++ b/scripts/supabase/verify-db.sh
@@ -21,13 +21,14 @@ fi
 if [[ -z "${SELF_HOSTED_DB_URL:-}" ]]; then
   SELF_HOSTED_DB_HOST="${SELF_HOSTED_DB_HOST:-blog-supabase.jongchoi.com}"
   POSTGRES_DB="${POSTGRES_DB:-postgres}"
+  POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 
   if [[ -z "${POSTGRES_PASSWORD:-}" || -z "${POOLER_TENANT_ID:-}" ]]; then
     echo "SELF_HOSTED_DB_URL is required unless POSTGRES_PASSWORD and POOLER_TENANT_ID are set." >&2
     exit 1
   fi
 
-  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:5432/${POSTGRES_DB}"
+  SELF_HOSTED_DB_URL="postgres://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@${SELF_HOSTED_DB_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 fi
 
 REPORT_FILE="${REPORT_FILE:-${DUMP_DIR}/self-hosted-inventory.txt}"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "infra/supabase/volumes/functions"]
 }

--- a/utils/uploadingUtils.tsx
+++ b/utils/uploadingUtils.tsx
@@ -41,8 +41,10 @@ export function slugify(title: string): string {
  * extractFirstImageFromText("텍스트만 있는 게시글"); // ""
  */
 export function extractFirstImageFromText(postText: string): string {
-  const commonImagePath =
-    "https://wknphwqwtywjrfclmhjd.supabase.co/storage/v1/object/public/image";
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    "https://wknphwqwtywjrfclmhjd.supabase.co";
+  const commonImagePath = `${supabaseUrl}/storage/v1/object/public/image`;
   const regex = new RegExp(
     `!\\[.*?\\]\\(((${commonImagePath}[^\\s)]+))\\)`,
     "i"


### PR DESCRIPTION
- Supabase 셀프 호스팅을 위해 infra 폴더를 신설하고 컴포즈 파일을 작성하였습니다.
- Supabase 덤프 파일 이관을 위한 스크립트 파일을 작성하였습니다.
- 셀프 호스팅은 CI/CD와 별개로 vps 내에서 진행되었으며, env의 supbase url을 수정하면 반영됩니다.

----

## 제목

Supabase self-hosting 인프라 및 마이그레이션 스크립트 추가

## 개요

Supabase Cloud에 의존하던 백엔드 구성을 VPS 기반 self-hosted Supabase로 이전하기 위한 Docker 구성, 마이그레이션 스크립트, Storage 동기화 스크립트를 추가했습니다.

또한 self-hosted Supabase 환경에서 이미지 도메인과 업로드 URL이 정상 동작하도록 앱 설정을 수정하고, README에 인프라 변경 내용을 반영했습니다.

## 변경 사항

- `infra/supabase` 하위에 self-hosted Supabase Docker Compose 구성 추가
- Kong, DB init SQL, Supavisor, Edge Functions, MinIO 연동 설정 추가
- Supabase Cloud DB dump 스크립트 추가
- self-hosted Supabase DB restore 스크립트 추가
- DB 복원 결과 검증 스크립트 추가
- Supabase Storage S3 동기화 스크립트 추가
- self-hosted Supabase 이미지 도메인을 Next.js remote image 허용 목록에 추가
- 이미지 추출 유틸이 `NEXT_PUBLIC_SUPABASE_URL` 기반 Storage URL을 사용하도록 수정
- Supabase restore/verify 스크립트가 `infra/supabase/.env`를 읽어 접속 정보를 구성하도록 수정
- README에 Supabase self-hosting 및 데이터 이전 내용 추가

## 커밋별 내용

### `9d1a3de` `[feat] 슈퍼베이스 셀프호스팅 도커 및 마이그레이션 스크립트 작성`

- self-hosted Supabase Docker Compose 구성 추가
- Supabase 관련 환경 변수 예시 및 README 추가
- DB dump/restore/verify 스크립트 추가
- Storage sync 스크립트 추가
- self-hosted Storage URL 대응 코드 추가
- 관련 튜토리얼 문서 추가

### `16d2616` `[chore] 복원 스크립트 수정`

- dump/restore/verify 스크립트가 `infra/supabase/.env`를 직접 읽도록 수정
- Supavisor tenant id와 Postgres port 기반으로 self-hosted DB 접속 문자열을 구성하도록 수정
- README에 Supabase self-hosting 이력과 배포 설명 추가

## 검증

- Supabase Cloud DB dump 생성 확인
- self-hosted Supabase DB restore 확인
- `public.posts` 테이블 및 게시글 데이터 복원 확인
- `analytics_events` 테이블 복원 확인
- RLS policy 복원 확인
- DB 함수 및 view 복원 확인
- Storage object 동기화 확인
- self-hosted Supabase REST API를 통한 게시글 조회 확인
- 앱에서 게시글 상세 페이지 및 analytics 요청 정상 동작 확인

## 참고

- DB 접속은 self-hosted Supabase의 Supavisor session pooler를 사용합니다.
- Storage 데이터는 DB dump와 별도로 S3 호환 API를 통해 동기화합니다.
- 복원 후 PostgREST schema cache 잔상은 reload 및 브라우저 강력 새로고침으로 정상화되었습니다.